### PR TITLE
Return values from both data and error channels at once

### DIFF
--- a/cgo/command.go
+++ b/cgo/command.go
@@ -81,14 +81,9 @@ func (conn *connection) execContext(ctx context.Context, query string) (*csComma
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case cmd := <-recvCmd:
-			if cmd != nil {
-				return cmd, nil
-			}
 		case err := <-recvErr:
-			if err != nil {
-				return nil, err
-			}
+			cmd := <-recvCmd
+			return cmd, err
 		}
 	}
 }

--- a/cgo/connector.go
+++ b/cgo/connector.go
@@ -33,6 +33,7 @@ func NewConnector(dsn libdsn.DsnInfo) (driver.Connector, error) {
 		driverCtx.drop()
 		return nil, fmt.Errorf("Failed to open connection: %v", err)
 	}
+
 	defer func() {
 		// In- and decrease connections count before and after closing
 		// connection to prevent the context being deallocated.
@@ -64,10 +65,9 @@ func (connector *connector) Connect(ctx context.Context) (driver.Conn, error) {
 			}
 		}()
 		return nil, ctx.Err()
-	case conn := <-connChan:
-		return conn, nil
 	case err := <-errChan:
-		return nil, err
+		conn := <-connChan
+		return conn, err
 	}
 }
 

--- a/cgo/statement.go
+++ b/cgo/statement.go
@@ -60,14 +60,9 @@ func (conn *connection) PrepareContext(ctx context.Context, query string) (drive
 				}
 			}()
 			return nil, ctx.Err()
-		case stmt := <-recvStmt:
-			if stmt != nil {
-				return stmt, nil
-			}
 		case err := <-recvErr:
-			if err != nil {
-				return nil, err
-			}
+			stmt := <-recvStmt
+			return stmt, err
 		}
 	}
 }
@@ -291,14 +286,9 @@ func (stmt *statement) ExecContext(ctx context.Context, args []driver.NamedValue
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case res := <-recvResult:
-			if res != nil {
-				return res, nil
-			}
 		case err := <-recvErr:
-			if err != nil {
-				return nil, err
-			}
+			res := <-recvResult
+			return res, err
 		}
 	}
 }
@@ -343,14 +333,9 @@ func (stmt *statement) QueryContext(ctx context.Context, args []driver.NamedValu
 				}
 			}()
 			return nil, ctx.Err()
-		case rows := <-recvRows:
-			if rows != nil {
-				return rows, nil
-			}
 		case err := <-recvErr:
-			if err != nil {
-				return nil, err
-			}
+			rows := <-recvRows
+			return rows, err
 		}
 	}
 }

--- a/cgo/transaction.go
+++ b/cgo/transaction.go
@@ -55,14 +55,9 @@ func (conn *connection) BeginTx(ctx context.Context, opts driver.TxOptions) (dri
 				}
 			}()
 			return nil, ctx.Err()
-		case tx := <-recvTx:
-			if tx != nil {
-				return tx, nil
-			}
 		case err := <-recvErr:
-			if err != nil {
-				return nil, err
-			}
+			tx := <-recvTx
+			return tx, err
 		}
 	}
 }


### PR DESCRIPTION
The error channel is always being written to and closed last, reading
all values like this and returning them at once removes the need for if
clauses.