### PR TITLE
Correct compile-time check for driver.Valuer instead of driver.Value

### DIFF
--- a/libase/types/gen_nulls.go
+++ b/libase/types/gen_nulls.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	_ driver.Value = (*Null{{.T}})(nil)
+	_ driver.Valuer = (*Null{{.T}})(nil)
 	_ sql.Scanner = (*Null{{.T}})(nil)
 )
 

--- a/libase/types/nullBytes.go
+++ b/libase/types/nullBytes.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	_ driver.Value = (*NullBytes)(nil)
-	_ sql.Scanner  = (*NullBytes)(nil)
+	_ driver.Valuer = (*NullBytes)(nil)
+	_ sql.Scanner   = (*NullBytes)(nil)
 )
 
 type NullBytes struct {

--- a/libase/types/nullTime.go
+++ b/libase/types/nullTime.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	_ driver.Value = (*NullTime)(nil)
-	_ sql.Scanner  = (*NullTime)(nil)
+	_ driver.Valuer = (*NullTime)(nil)
+	_ sql.Scanner   = (*NullTime)(nil)
 )
 
 type NullTime struct {


### PR DESCRIPTION
# Description

Fixes the compile-time check to check for the interface `driver.Valuer` instead of the type `driver.Value` (which is an `interface{}`).

# How was the patch tested?

`go test`