### PR TITLE
Add missing parameters for fmt.Errorf

### DIFF
--- a/cgo/connector.go
+++ b/cgo/connector.go
@@ -20,7 +20,7 @@ type connector struct {
 func NewConnector(dsn libdsn.DsnInfo) (driver.Connector, error) {
 	driverCtx, err := newCsContext(dsn)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize context: %v")
+		return nil, fmt.Errorf("Failed to initialize context: %v", err)
 	}
 
 	c := &connector{

--- a/libase/isolationlevels.go
+++ b/libase/isolationlevels.go
@@ -39,7 +39,7 @@ func IsolationLevelFromGo(lvl sql.IsolationLevel) (IsolationLevel, error) {
 	}
 
 	if aseLvl == LevelInvalid {
-		return LevelInvalid, fmt.Errorf("Isolation level %v is not supported by ASE")
+		return LevelInvalid, fmt.Errorf("Isolation level %v is not supported by ASE", lvl)
 	}
 
 	return aseLvl, nil


### PR DESCRIPTION
# Description

Previously received `err` wasn't passed to the `fmt.Errorf`.

# How was the patch tested?

Unit- and integration tests.