### PR TITLE
Rename libase/dsn -> libase/libdsn

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The simple DSN is a key/value string: `username=user password=pass host=hostname
 
 Values with spaces must be quoted using single or double quotes.
 
-Each member of `libase.dsn.DsnInfo` can be set using any of their
+Each member of `libase.libdsn.DsnInfo` can be set using any of their
 possible json tags. E.g. `.Host` will receive the values from the keys
 `host` and `hostname`.
 
@@ -149,7 +149,7 @@ will only honour the last given value for a property.
 #### Connector
 
 As an alternative to the string DSNs `cgo.NewConnector` accepts
-a `dsn.DsnInfo` directly and returns a `driver.Connector`, which can be
+a `libdsn.DsnInfo` directly and returns a `driver.Connector`, which can be
 passed to `sql.OpenDB`:
 
 ```go
@@ -158,12 +158,12 @@ package main
 import (
     "database/sql"
 
-    "github.com/SAP/go-ase/libase/dsn"
+    "github.com/SAP/go-ase/libase/libdsn"
     ase "github.com/SAP/go-ase/cgo"
 )
 
 func main() {
-    d := dsn.NewDsnInfo()
+    d := libdsn.NewDsnInfo()
     d.Host = "hostname"
     d.Port = "4901"
     d.Username = "user"

--- a/cgo/connection.go
+++ b/cgo/connection.go
@@ -11,7 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/SAP/go-ase/libase"
-	"github.com/SAP/go-ase/libase/dsn"
+	"github.com/SAP/go-ase/libase/libdsn"
 )
 
 // connection is the struct which represents a database connection.
@@ -36,7 +36,7 @@ var (
 // options in the dsn.
 //
 // If driverCtx is nil a new csContext will be initialized.
-func newConnection(driverCtx *csContext, dsn dsn.DsnInfo) (*connection, error) {
+func newConnection(driverCtx *csContext, dsn libdsn.DsnInfo) (*connection, error) {
 	if driverCtx == nil {
 		var err error
 		driverCtx, err = newCsContext(dsn)

--- a/cgo/connector.go
+++ b/cgo/connector.go
@@ -5,7 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 
-	libdsn "github.com/SAP/go-ase/libase/dsn"
+	"github.com/SAP/go-ase/libase/libdsn"
 )
 
 var _ driver.Connector = (*connector)(nil)

--- a/cgo/context.go
+++ b/cgo/context.go
@@ -7,15 +7,14 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/SAP/go-ase/libase/dsn"
-	libdsn "github.com/SAP/go-ase/libase/dsn"
+	"github.com/SAP/go-ase/libase/libdsn"
 )
 
 // context wraps C.CS_CONTEXT to ensure that the context is being closed
 // and deallocated after the last connection was closed.
 type csContext struct {
 	ctx *C.CS_CONTEXT
-	dsn dsn.DsnInfo
+	dsn libdsn.DsnInfo
 
 	// connections is a counter that keeps track of the number of
 	// connections using the context to communicate with an ASE
@@ -25,7 +24,7 @@ type csContext struct {
 	lock        sync.Mutex
 }
 
-func newCsContext(dsn dsn.DsnInfo) (*csContext, error) {
+func newCsContext(dsn libdsn.DsnInfo) (*csContext, error) {
 	ctx := &csContext{}
 	ctx.dsn = dsn
 

--- a/cgo/driver.go
+++ b/cgo/driver.go
@@ -14,7 +14,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 
-	libdsn "github.com/SAP/go-ase/libase/dsn"
+	"github.com/SAP/go-ase/libase/libdsn"
 )
 
 //DriverName is the driver name to use with sql.Open for ase databases.

--- a/cmd/cgo-ase/main.go
+++ b/cmd/cgo-ase/main.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	_ "github.com/SAP/go-ase/cgo"
-	libdsn "github.com/SAP/go-ase/libase/dsn"
 	"github.com/SAP/go-ase/libase/flagslice"
+	"github.com/SAP/go-ase/libase/libdsn"
 	"github.com/bgentry/speakeasy"
 )
 

--- a/examples/cgo/simple/main.go
+++ b/examples/cgo/simple/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	_ "github.com/SAP/go-ase/cgo"
-	libdsn "github.com/SAP/go-ase/libase/dsn"
+	"github.com/SAP/go-ase/libase/libdsn"
 )
 
 func main() {

--- a/libase/libdsn/dsn.go
+++ b/libase/libdsn/dsn.go
@@ -1,5 +1,5 @@
-// Package dsn handles data source names.
-package dsn
+// Package libdsn handles data source names.
+package libdsn
 
 import (
 	"fmt"

--- a/libase/libdsn/dsn_test.go
+++ b/libase/libdsn/dsn_test.go
@@ -1,4 +1,4 @@
-package dsn
+package libdsn
 
 import (
 	"net/url"

--- a/libase/libdsn/parse.go
+++ b/libase/libdsn/parse.go
@@ -1,4 +1,4 @@
-package dsn
+package libdsn
 
 import (
 	"fmt"

--- a/libase/libdsn/parse_test.go
+++ b/libase/libdsn/parse_test.go
@@ -1,4 +1,4 @@
-package dsn
+package libdsn
 
 import (
 	"net/url"

--- a/tests/libtest/dsn.go
+++ b/tests/libtest/dsn.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/SAP/go-ase/libase/dsn"
+	"github.com/SAP/go-ase/libase/libdsn"
 )
 
 // fromEnv reads an environment variable and returns the value.
@@ -34,10 +34,10 @@ func doCallbacks() bool {
 	return val == "yes"
 }
 
-// DSNFromEnv initializes a dsn.DsnInfo and fills it with information
+// DSNFromEnv initializes a libdsn.DsnInfo and fills it with information
 // from the environment.
-func DSNFromEnv() (*dsn.DsnInfo, error) {
-	dsnInfo := dsn.NewDsnInfo()
+func DSNFromEnv() (*libdsn.DsnInfo, error) {
+	dsnInfo := libdsn.NewDsnInfo()
 
 	var err error
 	dsnInfo.Host, err = fromEnv("ASE_HOST")
@@ -70,8 +70,8 @@ func DSNFromEnv() (*dsn.DsnInfo, error) {
 
 // DSNUserstoreFromEnv initializes a dsn.DsnInfo and retrieves the
 // userstorekey from the environment.
-func DSNUserstoreFromEnv() (*dsn.DsnInfo, error) {
-	dsnInfo := dsn.NewDsnInfo()
+func DSNUserstoreFromEnv() (*libdsn.DsnInfo, error) {
+	dsnInfo := libdsn.NewDsnInfo()
 
 	var err error
 
@@ -90,8 +90,8 @@ func DSNUserstoreFromEnv() (*dsn.DsnInfo, error) {
 
 // DSN creates a new dsn.DsnInfo, sets up a new database and returns the
 // DsnInfo and a function to tear down the database.
-func DSN(userstore bool) (*dsn.DsnInfo, func(), error) {
-	var dsn *dsn.DsnInfo
+func DSN(userstore bool) (*libdsn.DsnInfo, func(), error) {
+	var dsn *libdsn.DsnInfo
 	var err error
 	if !userstore {
 		dsn, err = DSNFromEnv()
@@ -129,13 +129,13 @@ var sqlDBMap = make(genSQLDBMap)
 
 // ConnectorCreator is the interface for function expected by InitDBs to
 // initialize driver.Connectors.
-type ConnectorCreator func(dsn.DsnInfo) (driver.Connector, error)
+type ConnectorCreator func(libdsn.DsnInfo) (driver.Connector, error)
 
 // RegisterDSN registers at least one new genSQLDBFn in genSQLDBMap
 // based on sql.Open.
 // If connectorFn is non-nil a second genSQLDBFn is stored with the
 // suffix `connector`.
-func RegisterDSN(name string, info dsn.DsnInfo, connectorFn ConnectorCreator) error {
+func RegisterDSN(name string, info libdsn.DsnInfo, connectorFn ConnectorCreator) error {
 	sqlDBMap[name] = func() (*sql.DB, error) {
 		db, err := sql.Open("ase", info.AsSimple())
 		if err != nil {

--- a/tests/libtest/setup_teardown.go
+++ b/tests/libtest/setup_teardown.go
@@ -5,11 +5,11 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/SAP/go-ase/libase/dsn"
+	"github.com/SAP/go-ase/libase/libdsn"
 )
 
 // SetupDB creates a database and sets .Database on the passed testDsn
-func SetupDB(testDsn *dsn.DsnInfo) error {
+func SetupDB(testDsn *libdsn.DsnInfo) error {
 	db, err := sql.Open("ase", testDsn.AsSimple())
 	if err != nil {
 		return fmt.Errorf("Failed to open database: %v", err)
@@ -45,7 +45,7 @@ func SetupDB(testDsn *dsn.DsnInfo) error {
 
 // TeardownDB deletes the database indicated by .Database of the passed
 // testDsn and unsets the member.
-func TeardownDB(testDsn *dsn.DsnInfo) error {
+func TeardownDB(testDsn *libdsn.DsnInfo) error {
 	db, err := sql.Open("ase", testDsn.AsSimple())
 	if err != nil {
 		return fmt.Errorf("Failed to open database: %v", err)


### PR DESCRIPTION
# Description

Renames `libase/dsn` to `libase/libdsn` as the package is renamed to `libdsn` in most places.

# How was the patch tested?

Lint, unit- and integration tests.