### PR TITLE
Add `key` as userstorekey tag and support properties with dashes from environment

### DIFF
--- a/libase/libdsn/dsn.go
+++ b/libase/libdsn/dsn.go
@@ -39,6 +39,11 @@ func NewDsnInfo() *DsnInfo {
 // Recognized environments variables are in the form of <prefix>_<json
 // tag>. E.g. `.Host` with the prefix `""` would recognize `ASE_HOST`
 // and `ASE_HOSTNAME`.
+//
+// Properties with dashes are recognized with double underscored
+// instead.
+// E.g. the property `cgo-callback-client` can be passed as
+// `CGO__CALLBACK__CLIENT`.
 func NewDsnInfoFromEnv(prefix string) *DsnInfo {
 	dsn := NewDsnInfo()
 
@@ -57,6 +62,7 @@ func NewDsnInfoFromEnv(prefix string) *DsnInfo {
 		}
 
 		key = strings.ToLower(strings.TrimPrefix(key, prefix))
+		key = strings.ReplaceAll(key, "__", "-")
 		if field, ok := ttf[key]; ok {
 			field.SetString(value)
 		} else {

--- a/libase/libdsn/dsn.go
+++ b/libase/libdsn/dsn.go
@@ -19,7 +19,7 @@ type DsnInfo struct {
 	Port         string     `json:"port" validate:"required"`
 	Username     string     `json:"user,username" validate:"required"`
 	Password     string     `json:"pass,passwd,password" validate:"required"`
-	Userstorekey string     `json:"userstorekey" validate:"required"`
+	Userstorekey string     `json:"userstorekey,key" validate:"required"`
 	Database     string     `json:"db,database"`
 	ConnectProps url.Values `json:"connectprops"`
 }


### PR DESCRIPTION
# Description

1. Add `key` as struct tag for usterstore keys in DsnInfo
2. Parse properties with dashes by replacing `__` with `-` when processing environment variables

# How was the patch tested?

Used in the test environment to enable/disable debug logging while running tests.