### PR TITLE
Add statement.columnTypes

### DIFF
--- a/cgo/connection.go
+++ b/cgo/connection.go
@@ -218,7 +218,7 @@ func (conn *Connection) ExecContext(ctx context.Context, query string, args []dr
 	defer cmd.Drop()
 
 	var result, resResult driver.Result
-	for _, result, err = cmd.Response(); err != io.EOF; _, result, err = cmd.Response() {
+	for _, result, _, err = cmd.Response(); err != io.EOF; _, result, _, err = cmd.Response() {
 		if err != nil {
 			return nil, fmt.Errorf("Received error reading results: %v", err)
 		}
@@ -251,7 +251,7 @@ func (conn *Connection) QueryContext(ctx context.Context, query string, args []d
 		return nil, fmt.Errorf("Failed to send command: %v", err)
 	}
 
-	rows, _, err := cmd.Response()
+	rows, _, _, err := cmd.Response()
 	if err != nil {
 		return nil, fmt.Errorf("Received error while retrieving results: %v", err)
 	}

--- a/cgo/rows.go
+++ b/cgo/rows.go
@@ -121,7 +121,7 @@ func (rows *Rows) Close() error {
 		}
 	}
 
-	for r, _, err := rows.cmd.Response(); err != io.EOF; r, _, err = rows.cmd.Response() {
+	for r, _, _, err := rows.cmd.Response(); err != io.EOF; r, _, _, err = rows.cmd.Response() {
 		if err != nil {
 			return fmt.Errorf("Received error reading results: %v", err)
 		}

--- a/cgo/statement.go
+++ b/cgo/statement.go
@@ -83,7 +83,7 @@ func (conn *Connection) prepare(query string) (driver.Stmt, error) {
 		return nil, err
 	}
 
-	for err = nil; err != io.EOF; _, _, err = cmd.Response() {
+	for err = nil; err != io.EOF; _, _, _, err = cmd.Response() {
 		if err != nil {
 			stmt.Close()
 			cmd.Cancel()
@@ -112,7 +112,7 @@ func (stmt *statement) Close() error {
 		}
 
 		var err error
-		for err = nil; err != io.EOF; _, _, err = stmt.cmd.Response() {
+		for err = nil; err != io.EOF; _, _, _, err = stmt.cmd.Response() {
 			if err != nil {
 				return err
 			}
@@ -241,7 +241,7 @@ func (stmt *statement) execResults() (driver.Result, error) {
 	var resResult driver.Result
 
 	for {
-		_, result, err := stmt.cmd.Response()
+		_, result, _, err := stmt.cmd.Response()
 		if err == io.EOF {
 			break
 		}
@@ -299,7 +299,7 @@ func (stmt *statement) Query(args []driver.Value) (driver.Rows, error) {
 		return nil, err
 	}
 
-	rows, _, err := stmt.cmd.Response()
+	rows, _, _, err := stmt.cmd.Response()
 	if err != nil {
 		return nil, err
 	}
@@ -316,7 +316,7 @@ func (stmt *statement) QueryContext(ctx context.Context, args []driver.NamedValu
 	recvRows := make(chan driver.Rows, 1)
 	recvErr := make(chan error, 1)
 	go func() {
-		rows, _, err := stmt.cmd.Response()
+		rows, _, _, err := stmt.cmd.Response()
 		recvRows <- rows
 		close(recvRows)
 		recvErr <- err

--- a/cmd/cgoase/helpers.go
+++ b/cmd/cgoase/helpers.go
@@ -19,7 +19,7 @@ func process(conn *cgo.Connection, query string) error {
 	defer cmd.Drop()
 
 	for {
-		rows, result, err := cmd.Response()
+		rows, result, _, err := cmd.Response()
 		if err != nil {
 			if err == io.EOF {
 				return nil


### PR DESCRIPTION
# Description

To accurately transform Go values to ASE values the column types rather than the Go types must be used. The need for this stems from the requirement to support all ASE datatypes.

The switch/case will be filled in the coming PRs.

# How was the patch tested?

Using the integration tests in the coming PRs.
