### PR TITLE
Handle LONGCHAR datatype

### DIFF
--- a/cgo/rows.go
+++ b/cgo/rows.go
@@ -280,7 +280,7 @@ func (rows *Rows) Next(dest []driver.Value) error {
 			t = t.Add(time.Duration(dur) * time.Microsecond)
 
 			dest[i] = t
-		case types.CHAR, types.VARCHAR:
+		case types.CHAR, types.VARCHAR, types.LONGCHAR:
 			dest[i] = C.GoString((*C.char)(rows.colData[i]))
 		case types.BINARY, types.IMAGE:
 			dest[i] = C.GoBytes(rows.colData[i], rows.dataFmts[i].maxlength)

--- a/cgo/statement.go
+++ b/cgo/statement.go
@@ -301,7 +301,7 @@ func (stmt *statement) exec(args []driver.NamedValue) error {
 
 			ptr = C.CBytes(bs)
 			defer C.free(ptr)
-		case types.CHAR:
+		case types.CHAR, types.LONGCHAR:
 			ptr = unsafe.Pointer(C.CString(arg.Value.(string)))
 			defer C.free(ptr)
 


### PR DESCRIPTION
This commit handles the LONGCHAR datatype by treating it same
as CHAR and VARCHAR. This fixes the issue #45.

Issue: #45

# Description

There was an issue with LONGCHAR data type as it wasn't handled.
Following error was seen during 'make examples'
```
Opening database
Creating table 'simple'
Writing a=2147483647, b='a string' to table
Querying values from table
Displaying results of query
| a          | b                              |
2020/05/25 09:46:34 Failed: Error reading rows: Unhandled Go type: LONGCHAR
exit status 1
make: *** [Makefile:24: examples/cgo/simple] Error 1
```

# How was the patch tested?

The patch was tested with the existing examples and all examples could be run successfully.
```
$:~/opensource_repo/go-ase> make examples
Running example: examples/cgo/simple
go run ./examples/cgo/simple/main.go
# github.com/SAP/go-ase/cgo
bridge.c: In function ‘ct_callback_server_message’:
bridge.c:6:9: warning: implicit declaration of function ‘srvMsg’ [-Wimplicit-function-declaration]
  return srvMsg(msg);
         ^~~~~~
bridge.c: In function ‘ct_callback_client_message’:
bridge.c:10:9: warning: implicit declaration of function ‘cltMsg’ [-Wimplicit-function-declaration]
  return cltMsg(msg);
         ^~~~~~
Opening database
Creating table 'simple'
Writing a=2147483647, b='a string' to table
Querying values from table
Displaying results of query
| a          | b                              |
| 2147483647 | a string                       |
Running example: examples/cgo/recorder
go run ./examples/cgo/recorder/main.go
# github.com/SAP/go-ase/cgo
bridge.c: In function ‘ct_callback_server_message’:
bridge.c:6:9: warning: implicit declaration of function ‘srvMsg’ [-Wimplicit-function-declaration]
  return srvMsg(msg);
         ^~~~~~
bridge.c: In function ‘ct_callback_client_message’:
bridge.c:10:9: warning: implicit declaration of function ‘cltMsg’ [-Wimplicit-function-declaration]
  return cltMsg(msg);
         ^~~~~~
Opening database
Creating MessageRecorder
Registering handler with server message broker
Enable traceflag 3604
Received messages:
DBCC execution completed. If DBCC printed error messages, contact a user with System Administrator (SA) role.
Listing enabled traceflags
Received messages:
Active traceflags: 1623, 3604

DBCC execution completed. If DBCC printed error messages, contact a user with System Administrator (SA) role.
```
Integration Tests:
```
I302026@linux-jtio:~/opensource_repo/go-ase> make integration
go test ./tests/cgotest
# github.com/SAP/go-ase/cgo
bridge.c: In function ‘ct_callback_server_message’:
bridge.c:6:9: warning: implicit declaration of function ‘srvMsg’ [-Wimplicit-function-declaration]
  return srvMsg(msg);
         ^~~~~~
bridge.c: In function ‘ct_callback_client_message’:
bridge.c:10:9: warning: implicit declaration of function ‘cltMsg’ [-Wimplicit-function-declaration]
  return cltMsg(msg);
         ^~~~~~
ok  	github.com/SAP/go-ase/tests/cgotest	(cached)
go test ./examples/cgo/...
# github.com/SAP/go-ase/cgo
bridge.c: In function ‘ct_callback_server_message’:
bridge.c:6:9: warning: implicit declaration of function ‘srvMsg’ [-Wimplicit-function-declaration]
  return srvMsg(msg);
         ^~~~~~
bridge.c: In function ‘ct_callback_client_message’:
bridge.c:10:9: warning: implicit declaration of function ‘cltMsg’ [-Wimplicit-function-declaration]
  return cltMsg(msg);
         ^~~~~~
ok  	github.com/SAP/go-ase/examples/cgo/recorder	(cached)
ok  	github.com/SAP/go-ase/examples/cgo/simple	(cached)
```