### PR TITLE
Fix cgo compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ shared objects required for the cgo driver.
 Compilation:
 
 ```sh
-CGO_LDFLAGS="-L/path/to/OCS/lib -lsybct_r64 -lsybcs_r64" go build -o cmd ./
+CGO_LDFLAGS="-L/path/to/OCS/lib" go build -o cmd ./
 ```
 
 Execution:

--- a/cgo/bridge.h
+++ b/cgo/bridge.h
@@ -4,4 +4,7 @@
 CS_RETCODE ct_callback_server_message(CS_CONTEXT*, CS_CONNECTION*, CS_SERVERMSG*);
 CS_RETCODE ct_callback_client_message(CS_CONTEXT*, CS_CONNECTION*, CS_CLIENTMSG*);
 
+CS_RETCODE srvMsg(CS_SERVERMSG*);
+CS_RETCODE cltMsg(CS_CLIENTMSG*);
+
 #endif

--- a/cgo/driver.go
+++ b/cgo/driver.go
@@ -3,6 +3,7 @@ package cgo
 
 /*
 #cgo CFLAGS: -I${SRCDIR}/includes
+#cgo LDFLAGS: -lsybct64 -lsybct_r64 -lsybcs_r64 -lsybtcl_r64 -lsybcomn_r64 -lsybintl_r64 -lsybunic64
 #cgo LDFLAGS: -Wl,-rpath,\$ORIGIN/../lib
 #include <stdlib.h>
 #include "ctlib.h"


### PR DESCRIPTION
# Description

1. Move targeted shared objects into a CGO directive
    Note: The required shared objects changed between versions - I'll have to test against different ASE and Client-Library versions for #46 anyhow, so it can be left as this for now
2. Defines the go native functions used in C code in the C header
    This is required now since cgo now passes more restrictive flags to the C compiler

# How was the patch tested?

Using `make test` and `make integration`.
