### PR TITLE
Minor fixes and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ build: $(BINS)
 $(BINS):
 	go build -o $@ ./cmd/$@/
 
+generate:
+	go generate ./...
+
 test:
 	go test -vet all -cover ./cgo/... ./go/... ./cmd/... ./libase/...
 

--- a/cgo/Makefile
+++ b/cgo/Makefile
@@ -1,9 +1,0 @@
-default: build
-
-.PHONY: build
-build:
-	go build .
-
-.PHONY: test
-test: build
-	go test

--- a/cgo/context.go
+++ b/cgo/context.go
@@ -105,7 +105,7 @@ func (context *csContext) drop() error {
 
 	retval = C.cs_ctx_drop(context.ctx)
 	if retval != C.CS_SUCCEED {
-		return makeError(retval, "C.cs_ctx_drop frailed")
+		return makeError(retval, "C.cs_ctx_drop failed")
 	}
 
 	context.ctx = nil


### PR DESCRIPTION
# Description

Some minor fixes and cleanup that didn't fit with the other PRs.

1, Add the `generate` recipe. We may expand this later to be targetet, since one run currently takes 1.5m
2. Removed old makefile
3. Fix typo

# How was the patch tested?

Using `make test` and `make integration`.
