### PR TITLE
Update cgo uses of interface/struct

### DIFF
--- a/cgo/recorder.go
+++ b/cgo/recorder.go
@@ -35,6 +35,6 @@ func (rec *MessageRecorder) HandleMessage(msg Message) {
 }
 
 // Text returns the received messages.
-func (rec MessageRecorder) Text() []string {
+func (rec *MessageRecorder) Text() []string {
 	return rec.Messages
 }

--- a/cmd/cgoase/callback.go
+++ b/cmd/cgoase/callback.go
@@ -11,5 +11,5 @@ func handleMessage(msg cgo.Message) {
 		return
 	}
 
-	log.Println(msg.Content)
+	log.Println(msg.Content())
 }


### PR DESCRIPTION
# Description

Fixes two issues that slipped through - both are explained in their respective commits.
Essentially the interface/structs they access were changed and their uses weren't updated.

# How was the patch tested?

Using `make test` and `make integration`.
