### PR TITLE
Add missing datatypes for cgo implementation

### DIFF
--- a/cgo/rows.go
+++ b/cgo/rows.go
@@ -280,7 +280,7 @@ func (rows *Rows) Next(dest []driver.Value) error {
 			t = t.Add(time.Duration(dur) * time.Microsecond)
 
 			dest[i] = t
-		case types.CHAR, types.VARCHAR:
+		case types.CHAR, types.VARCHAR, types.TEXT:
 			dest[i] = C.GoString((*C.char)(rows.colData[i]))
 		case types.BINARY, types.IMAGE:
 			dest[i] = C.GoBytes(rows.colData[i], rows.dataFmts[i].maxlength)
@@ -289,6 +289,10 @@ func (rows *Rows) Next(dest []driver.Value) error {
 			if int(*(*C.CS_BIT)(rows.colData[i])) == 1 {
 				dest[i] = true
 			}
+
+		case types.UNICHAR, types.UNITEXT:
+			b := C.GoBytes(rows.colData[i], rows.dataFmts[i].maxlength)
+			dest[i] = string(b)
 		default:
 			return fmt.Errorf("Unhandled Go type: %+v", rows.colASEType[i])
 		}

--- a/cgo/statement.go
+++ b/cgo/statement.go
@@ -349,6 +349,13 @@ func (stmt *statement) exec(args []driver.NamedValue) error {
 			}
 			ptr = unsafe.Pointer(&b)
 			datalen = 1
+		case types.UNICHAR, types.TEXT, types.UNITEXT:
+			ptr = unsafe.Pointer(C.CString(arg.Value.(string)))
+			defer C.free(ptr)
+
+			datalen = len(arg.Value.(string)) * 2
+			datafmt.format = C.CS_FMT_NULLTERM
+			datafmt.maxlength = C.CS_MAX_CHAR
 		default:
 			return fmt.Errorf("Unhandled column type: %s", stmt.columnTypes[i])
 		}

--- a/tests/cgotest/main_test.go
+++ b/tests/cgotest/main_test.go
@@ -88,6 +88,9 @@ func TestVarChar(t *testing.T)  { libtest.DoTestVarChar(t) }
 func TestChar(t *testing.T)     { libtest.DoTestChar(t) }
 func TestNChar(t *testing.T)    { libtest.DoTestNChar(t) }
 func TestNVarChar(t *testing.T) { libtest.DoTestNVarChar(t) }
+func TestText(t *testing.T)     { libtest.DoTestText(t) }
+func TestUniChar(t *testing.T)  { libtest.DoTestUniChar(t) }
+func TestUniText(t *testing.T)  { libtest.DoTestUniText(t) }
 
 // Binary
 func TestBinary(t *testing.T)    { libtest.DoTestBinary(t) }

--- a/tests/libtest/samples.go
+++ b/tests/libtest/samples.go
@@ -211,3 +211,17 @@ var samplesBit = []bool{true, false}
 //go:generate go run ./gen_type.go Image []byte -compare compareBinary
 // TODO: -null github.com/SAP/go-ase/libase/types.NullBinary
 var samplesImage = [][]byte{[]byte("test"), []byte("a longer test")}
+
+// TODO: Separate null test, ctlib transforms empty value to null
+//go:generate go run ./gen_type.go UniChar string -columndef "unichar(2) null" -compare compareChar
+// TODO: -null database/sql.NullString
+var samplesUniChar = []string{"", "你好"}
+
+// TODO: Separate null test, ctlib transforms empty value to null
+//go:generate go run ./gen_type.go Text string -columndef "text null" -compare compareChar
+// TODO: -null database/sql.NullString
+var samplesText = []string{"", "a long text"}
+
+//go:generate go run ./gen_type.go UniText string -columndef unitext -compare compareChar
+// TODO: -null database/sql.NullString
+var samplesUniText = []string{"a long text", "你好"}

--- a/tests/libtest/type_text.go
+++ b/tests/libtest/type_text.go
@@ -1,0 +1,56 @@
+package libtest
+
+import (
+	"database/sql"
+
+	"testing"
+)
+
+// DoTestText tests the handling of the Text.
+func DoTestText(t *testing.T) {
+	TestForEachDB("TestText", t, testText)
+	//
+}
+
+func testText(t *testing.T, db *sql.DB, tableName string) {
+	pass := make([]interface{}, len(samplesText))
+	mySamples := make([]string, len(samplesText))
+
+	for i, sample := range samplesText {
+
+		mySample := sample
+
+		pass[i] = mySample
+		mySamples[i] = mySample
+	}
+
+	rows, err := SetupTableInsert(db, tableName, "text null", pass...)
+	if err != nil {
+		t.Errorf("Error preparing table: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	i := 0
+	var recv string
+	for rows.Next() {
+		err = rows.Scan(&recv)
+		if err != nil {
+			t.Errorf("Scan failed on %dth scan: %v", i, err)
+			continue
+		}
+
+		if compareChar(recv, mySamples[i]) {
+
+			t.Errorf("Received value does not match passed parameter")
+			t.Errorf("Expected: %v", mySamples[i])
+			t.Errorf("Received: %v", recv)
+		}
+
+		i++
+	}
+
+	if err := rows.Err(); err != nil {
+		t.Errorf("Error preparing rows: %v", err)
+	}
+}

--- a/tests/libtest/type_unichar.go
+++ b/tests/libtest/type_unichar.go
@@ -1,0 +1,56 @@
+package libtest
+
+import (
+	"database/sql"
+
+	"testing"
+)
+
+// DoTestUniChar tests the handling of the UniChar.
+func DoTestUniChar(t *testing.T) {
+	TestForEachDB("TestUniChar", t, testUniChar)
+	//
+}
+
+func testUniChar(t *testing.T, db *sql.DB, tableName string) {
+	pass := make([]interface{}, len(samplesUniChar))
+	mySamples := make([]string, len(samplesUniChar))
+
+	for i, sample := range samplesUniChar {
+
+		mySample := sample
+
+		pass[i] = mySample
+		mySamples[i] = mySample
+	}
+
+	rows, err := SetupTableInsert(db, tableName, "unichar(2) null", pass...)
+	if err != nil {
+		t.Errorf("Error preparing table: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	i := 0
+	var recv string
+	for rows.Next() {
+		err = rows.Scan(&recv)
+		if err != nil {
+			t.Errorf("Scan failed on %dth scan: %v", i, err)
+			continue
+		}
+
+		if compareChar(recv, mySamples[i]) {
+
+			t.Errorf("Received value does not match passed parameter")
+			t.Errorf("Expected: %v", mySamples[i])
+			t.Errorf("Received: %v", recv)
+		}
+
+		i++
+	}
+
+	if err := rows.Err(); err != nil {
+		t.Errorf("Error preparing rows: %v", err)
+	}
+}

--- a/tests/libtest/type_unitext.go
+++ b/tests/libtest/type_unitext.go
@@ -1,0 +1,56 @@
+package libtest
+
+import (
+	"database/sql"
+
+	"testing"
+)
+
+// DoTestUniText tests the handling of the UniText.
+func DoTestUniText(t *testing.T) {
+	TestForEachDB("TestUniText", t, testUniText)
+	//
+}
+
+func testUniText(t *testing.T, db *sql.DB, tableName string) {
+	pass := make([]interface{}, len(samplesUniText))
+	mySamples := make([]string, len(samplesUniText))
+
+	for i, sample := range samplesUniText {
+
+		mySample := sample
+
+		pass[i] = mySample
+		mySamples[i] = mySample
+	}
+
+	rows, err := SetupTableInsert(db, tableName, "unitext", pass...)
+	if err != nil {
+		t.Errorf("Error preparing table: %v", err)
+		return
+	}
+	defer rows.Close()
+
+	i := 0
+	var recv string
+	for rows.Next() {
+		err = rows.Scan(&recv)
+		if err != nil {
+			t.Errorf("Scan failed on %dth scan: %v", i, err)
+			continue
+		}
+
+		if compareChar(recv, mySamples[i]) {
+
+			t.Errorf("Received value does not match passed parameter")
+			t.Errorf("Expected: %v", mySamples[i])
+			t.Errorf("Received: %v", recv)
+		}
+
+		i++
+	}
+
+	if err := rows.Err(); err != nil {
+		t.Errorf("Error preparing rows: %v", err)
+	}
+}


### PR DESCRIPTION
# Description

This adds the missing cgo types `TEXT`, `UNICHAR` and `UNITEXT` as well as their respective tests and samples for integration tests.

# How was the patch tested?

Using `make test` and `make integration`.
