### PR TITLE
Prevent transaction log overflow in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/SAP/go-ase
 
+go 1.14
+
 require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e

--- a/tests/libtest/gen_type.go
+++ b/tests/libtest/gen_type.go
@@ -52,12 +52,13 @@ func test{{.ASEType}}(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "{{if .ColumnDef}}{{.ColumnDef}}{{else}}{{.ASETypeLower}}{{end}}", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "{{if .ColumnDef}}{{.ColumnDef}}{{else}}{{.ASETypeLower}}{{end}}", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv {{.GoType}}

--- a/tests/libtest/samples.go
+++ b/tests/libtest/samples.go
@@ -211,3 +211,17 @@ var samplesBit = []bool{true, false}
 //go:generate go run ./gen_type.go Image []byte -compare compareBinary
 // TODO: -null github.com/SAP/go-ase/libase/types.NullBinary
 var samplesImage = [][]byte{[]byte("test"), []byte("a longer test")}
+
+// TODO: Separate null test, ctlib transforms empty value to null
+//go:generate go run ./gen_type.go UniChar string -columndef "unichar(30) null" -compare compareChar
+// TODO: -null database/sql.NullString
+var samplesUniChar = []string{"", "not a unicode example"}
+
+// TODO: Separate null test, ctlib transforms empty value to null
+//go:generate go run ./gen_type.go Text string -columndef "text null" -compare compareChar
+// TODO: -null database/sql.NullString
+var samplesText = []string{"", "a long text"}
+
+//go:generate go run ./gen_type.go UniText string -columndef unitext -compare compareChar
+// TODO: -null database/sql.NullString
+var samplesUniText = []string{"not a unicode example", "another not unicode example"}

--- a/tests/libtest/type_bigint.go
+++ b/tests/libtest/type_bigint.go
@@ -24,12 +24,13 @@ func testBigInt(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "bigint", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "bigint", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv int64

--- a/tests/libtest/type_bigtime.go
+++ b/tests/libtest/type_bigtime.go
@@ -26,12 +26,13 @@ func testBigTime(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "bigtime", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "bigtime", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv time.Time

--- a/tests/libtest/type_binary.go
+++ b/tests/libtest/type_binary.go
@@ -24,12 +24,13 @@ func testBinary(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "binary(13)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "binary(13)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv []byte

--- a/tests/libtest/type_bit.go
+++ b/tests/libtest/type_bit.go
@@ -24,12 +24,13 @@ func testBit(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "bit", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "bit", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv bool

--- a/tests/libtest/type_char.go
+++ b/tests/libtest/type_char.go
@@ -24,12 +24,13 @@ func testChar(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "char(13)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "char(13)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv string

--- a/tests/libtest/type_date.go
+++ b/tests/libtest/type_date.go
@@ -26,12 +26,13 @@ func testDate(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "date", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "date", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv time.Time

--- a/tests/libtest/type_datetime.go
+++ b/tests/libtest/type_datetime.go
@@ -26,12 +26,13 @@ func testDateTime(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "datetime", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "datetime", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv time.Time

--- a/tests/libtest/type_decimal.go
+++ b/tests/libtest/type_decimal.go
@@ -31,12 +31,13 @@ func testDecimal(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "decimal(38,19)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "decimal(38,19)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv *types.Decimal

--- a/tests/libtest/type_decimal10.go
+++ b/tests/libtest/type_decimal10.go
@@ -31,12 +31,13 @@ func testDecimal10(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "decimal(1,0)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "decimal(1,0)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv *types.Decimal

--- a/tests/libtest/type_decimal380.go
+++ b/tests/libtest/type_decimal380.go
@@ -31,12 +31,13 @@ func testDecimal380(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "decimal(38,0)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "decimal(38,0)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv *types.Decimal

--- a/tests/libtest/type_decimal3838.go
+++ b/tests/libtest/type_decimal3838.go
@@ -31,12 +31,13 @@ func testDecimal3838(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "decimal(38,38)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "decimal(38,38)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv *types.Decimal

--- a/tests/libtest/type_float.go
+++ b/tests/libtest/type_float.go
@@ -24,12 +24,13 @@ func testFloat(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "float", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "float", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv float64

--- a/tests/libtest/type_image.go
+++ b/tests/libtest/type_image.go
@@ -24,12 +24,13 @@ func testImage(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "image", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "image", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv []byte

--- a/tests/libtest/type_int.go
+++ b/tests/libtest/type_int.go
@@ -24,12 +24,13 @@ func testInt(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "int", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "int", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv int32

--- a/tests/libtest/type_money.go
+++ b/tests/libtest/type_money.go
@@ -31,12 +31,13 @@ func testMoney(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "money", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "money", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv *types.Decimal

--- a/tests/libtest/type_money4.go
+++ b/tests/libtest/type_money4.go
@@ -31,12 +31,13 @@ func testMoney4(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "smallmoney", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "smallmoney", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv *types.Decimal

--- a/tests/libtest/type_nchar.go
+++ b/tests/libtest/type_nchar.go
@@ -24,12 +24,13 @@ func testNChar(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "nchar(13)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "nchar(13)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv string

--- a/tests/libtest/type_nvarchar.go
+++ b/tests/libtest/type_nvarchar.go
@@ -24,12 +24,13 @@ func testNVarChar(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "nvarchar(13)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "nvarchar(13)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv string

--- a/tests/libtest/type_real.go
+++ b/tests/libtest/type_real.go
@@ -24,12 +24,13 @@ func testReal(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "real", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "real", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv float64

--- a/tests/libtest/type_smalldatetime.go
+++ b/tests/libtest/type_smalldatetime.go
@@ -26,12 +26,13 @@ func testSmallDateTime(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "smalldatetime", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "smalldatetime", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv time.Time

--- a/tests/libtest/type_smallint.go
+++ b/tests/libtest/type_smallint.go
@@ -24,12 +24,13 @@ func testSmallInt(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "smallint", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "smallint", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv int16

--- a/tests/libtest/type_text.go
+++ b/tests/libtest/type_text.go
@@ -4,21 +4,19 @@ import (
 	"database/sql"
 
 	"testing"
-
-	"time"
 )
 
-// DoTestBigDateTime tests the handling of the BigDateTime.
-func DoTestBigDateTime(t *testing.T) {
-	TestForEachDB("TestBigDateTime", t, testBigDateTime)
+// DoTestText tests the handling of the Text.
+func DoTestText(t *testing.T) {
+	TestForEachDB("TestText", t, testText)
 	//
 }
 
-func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
-	pass := make([]interface{}, len(samplesBigDateTime))
-	mySamples := make([]time.Time, len(samplesBigDateTime))
+func testText(t *testing.T, db *sql.DB, tableName string) {
+	pass := make([]interface{}, len(samplesText))
+	mySamples := make([]string, len(samplesText))
 
-	for i, sample := range samplesBigDateTime {
+	for i, sample := range samplesText {
 
 		mySample := sample
 
@@ -26,7 +24,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, teardownFn, err := SetupTableInsert(db, tableName, "bigdatetime", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "text null", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
@@ -35,7 +33,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 	defer teardownFn()
 
 	i := 0
-	var recv time.Time
+	var recv string
 	for rows.Next() {
 		err = rows.Scan(&recv)
 		if err != nil {
@@ -43,7 +41,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 			continue
 		}
 
-		if recv != mySamples[i] {
+		if compareChar(recv, mySamples[i]) {
 
 			t.Errorf("Received value does not match passed parameter")
 			t.Errorf("Expected: %v", mySamples[i])

--- a/tests/libtest/type_time.go
+++ b/tests/libtest/type_time.go
@@ -26,12 +26,13 @@ func testTime(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "time", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "time", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv time.Time

--- a/tests/libtest/type_tinyint.go
+++ b/tests/libtest/type_tinyint.go
@@ -24,12 +24,13 @@ func testTinyInt(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "tinyint", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "tinyint", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv uint8

--- a/tests/libtest/type_unichar.go
+++ b/tests/libtest/type_unichar.go
@@ -4,21 +4,19 @@ import (
 	"database/sql"
 
 	"testing"
-
-	"time"
 )
 
-// DoTestBigDateTime tests the handling of the BigDateTime.
-func DoTestBigDateTime(t *testing.T) {
-	TestForEachDB("TestBigDateTime", t, testBigDateTime)
+// DoTestUniChar tests the handling of the UniChar.
+func DoTestUniChar(t *testing.T) {
+	TestForEachDB("TestUniChar", t, testUniChar)
 	//
 }
 
-func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
-	pass := make([]interface{}, len(samplesBigDateTime))
-	mySamples := make([]time.Time, len(samplesBigDateTime))
+func testUniChar(t *testing.T, db *sql.DB, tableName string) {
+	pass := make([]interface{}, len(samplesUniChar))
+	mySamples := make([]string, len(samplesUniChar))
 
-	for i, sample := range samplesBigDateTime {
+	for i, sample := range samplesUniChar {
 
 		mySample := sample
 
@@ -26,7 +24,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, teardownFn, err := SetupTableInsert(db, tableName, "bigdatetime", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "unichar(30) null", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
@@ -35,7 +33,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 	defer teardownFn()
 
 	i := 0
-	var recv time.Time
+	var recv string
 	for rows.Next() {
 		err = rows.Scan(&recv)
 		if err != nil {
@@ -43,7 +41,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 			continue
 		}
 
-		if recv != mySamples[i] {
+		if compareChar(recv, mySamples[i]) {
 
 			t.Errorf("Received value does not match passed parameter")
 			t.Errorf("Expected: %v", mySamples[i])

--- a/tests/libtest/type_unitext.go
+++ b/tests/libtest/type_unitext.go
@@ -4,21 +4,19 @@ import (
 	"database/sql"
 
 	"testing"
-
-	"time"
 )
 
-// DoTestBigDateTime tests the handling of the BigDateTime.
-func DoTestBigDateTime(t *testing.T) {
-	TestForEachDB("TestBigDateTime", t, testBigDateTime)
+// DoTestUniText tests the handling of the UniText.
+func DoTestUniText(t *testing.T) {
+	TestForEachDB("TestUniText", t, testUniText)
 	//
 }
 
-func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
-	pass := make([]interface{}, len(samplesBigDateTime))
-	mySamples := make([]time.Time, len(samplesBigDateTime))
+func testUniText(t *testing.T, db *sql.DB, tableName string) {
+	pass := make([]interface{}, len(samplesUniText))
+	mySamples := make([]string, len(samplesUniText))
 
-	for i, sample := range samplesBigDateTime {
+	for i, sample := range samplesUniText {
 
 		mySample := sample
 
@@ -26,7 +24,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, teardownFn, err := SetupTableInsert(db, tableName, "bigdatetime", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "unitext", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
@@ -35,7 +33,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 	defer teardownFn()
 
 	i := 0
-	var recv time.Time
+	var recv string
 	for rows.Next() {
 		err = rows.Scan(&recv)
 		if err != nil {
@@ -43,7 +41,7 @@ func testBigDateTime(t *testing.T, db *sql.DB, tableName string) {
 			continue
 		}
 
-		if recv != mySamples[i] {
+		if compareChar(recv, mySamples[i]) {
 
 			t.Errorf("Received value does not match passed parameter")
 			t.Errorf("Expected: %v", mySamples[i])

--- a/tests/libtest/type_unsignedbigint.go
+++ b/tests/libtest/type_unsignedbigint.go
@@ -24,12 +24,13 @@ func testUnsignedBigInt(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "unsigned bigint", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "unsigned bigint", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv uint64

--- a/tests/libtest/type_unsignedint.go
+++ b/tests/libtest/type_unsignedint.go
@@ -24,12 +24,13 @@ func testUnsignedInt(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "unsigned int", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "unsigned int", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv uint32

--- a/tests/libtest/type_unsignedsmallint.go
+++ b/tests/libtest/type_unsignedsmallint.go
@@ -24,12 +24,13 @@ func testUnsignedSmallInt(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "unsigned smallint", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "unsigned smallint", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv uint16

--- a/tests/libtest/type_varbinary.go
+++ b/tests/libtest/type_varbinary.go
@@ -24,12 +24,13 @@ func testVarBinary(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "varbinary(13)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "varbinary(13)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv []byte

--- a/tests/libtest/type_varchar.go
+++ b/tests/libtest/type_varchar.go
@@ -24,12 +24,13 @@ func testVarChar(t *testing.T, db *sql.DB, tableName string) {
 		mySamples[i] = mySample
 	}
 
-	rows, err := SetupTableInsert(db, tableName, "varchar(13)", pass...)
+	rows, teardownFn, err := SetupTableInsert(db, tableName, "varchar(13)", pass...)
 	if err != nil {
 		t.Errorf("Error preparing table: %v", err)
 		return
 	}
 	defer rows.Close()
+	defer teardownFn()
 
 	i := 0
 	var recv string


### PR DESCRIPTION
# Description

The problem this PR fixes was discovered while working on #50 and hence includes the already fixed test files for #50.

The default transaction log size may be too small for all test data to exist concurrently, since all tests are executed four times (username/password directly and through connector, userstorekey directly and through connector).

Instead of resizing the test database on creation or requiring developers to modify their database the tables are dropped immediately after their respective test has finished.

# How was the patch tested?

`make integration`
