### PR TITLE
Exit with non-zero return code on errors

### DIFF
--- a/cmd/cgoase/helpers.go
+++ b/cmd/cgoase/helpers.go
@@ -15,7 +15,7 @@ import (
 func process(conn *cgo.Connection, query string) error {
 	cmd, err := conn.GenericExec(context.Background(), query)
 	if err != nil {
-		return fmt.Errorf("Query failed: %v", err)
+		return fmt.Errorf("Query failed: %w", err)
 	}
 	defer cmd.Drop()
 
@@ -26,7 +26,7 @@ func process(conn *cgo.Connection, query string) error {
 				return nil
 			}
 			cmd.Cancel()
-			return fmt.Errorf("Reading response failed: %v", err)
+			return fmt.Errorf("Reading response failed: %w", err)
 		}
 
 		if rows != nil {
@@ -69,7 +69,7 @@ func processRows(rows *cgo.Rows) error {
 				break
 			}
 
-			return fmt.Errorf("Scanning cells failed: %v", err)
+			return fmt.Errorf("Scanning cells failed: %w", err)
 		}
 
 		for i, cell := range cells {
@@ -90,7 +90,7 @@ func processRows(rows *cgo.Rows) error {
 func processResult(result *cgo.Result) error {
 	affectedRows, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("Retrieving the affected rows failed: %v", err)
+		return fmt.Errorf("Retrieving the affected rows failed: %w", err)
 	}
 
 	if affectedRows >= 0 {

--- a/cmd/cgoase/main.go
+++ b/cmd/cgoase/main.go
@@ -66,7 +66,7 @@ func openDB() (*cgo.Connection, error) {
 
 	conn, err := cgo.NewConnection(nil, *dsn)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open connection: %v", err)
+		return nil, fmt.Errorf("Failed to open connection: %w", err)
 	}
 
 	return conn, nil
@@ -97,7 +97,7 @@ func doMain() error {
 
 	conn, err := openDB()
 	if err != nil {
-		return fmt.Errorf("Failed to connect to database: %v", err)
+		return fmt.Errorf("Failed to connect to database: %w", err)
 	}
 	defer conn.Close()
 

--- a/cmd/cgoase/main.go
+++ b/cmd/cgoase/main.go
@@ -81,6 +81,14 @@ func serverMessagePrint(msg cgo.Message) {
 }
 
 func main() {
+	err := doMain()
+	if err != nil {
+		log.Println(err)
+		os.Exit(1)
+	}
+}
+
+func doMain() error {
 	flag.Var(fOpts, "o", "Connection properties")
 	flag.Parse()
 
@@ -89,8 +97,7 @@ func main() {
 
 	conn, err := openDB()
 	if err != nil {
-		log.Printf("Failed to connect to database: %v", err)
-		return
+		return fmt.Errorf("Failed to connect to database: %v", err)
 	}
 	defer conn.Close()
 
@@ -103,8 +110,5 @@ func main() {
 		err = repl(conn)
 	}
 
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	return err
 }

--- a/cmd/cgoase/repl.go
+++ b/cmd/cgoase/repl.go
@@ -16,7 +16,7 @@ func repl(conn *cgo.Connection) error {
 	var err error
 	rl, err = readline.New("> ")
 	if err != nil {
-		return fmt.Errorf("Failed to initialize readline: %v", err)
+		return fmt.Errorf("Failed to initialize readline: %w", err)
 	}
 	defer rl.Close()
 
@@ -27,7 +27,7 @@ func repl(conn *cgo.Connection) error {
 			if err == io.EOF {
 				return nil
 			}
-			return fmt.Errorf("Received error from readline: %v", err)
+			return fmt.Errorf("Received error from readline: %w", err)
 		}
 
 		line = strings.TrimSpace(line)
@@ -74,7 +74,7 @@ func parseAndExecQueries(conn *cgo.Connection, line string) error {
 			} else {
 				err := process(conn, builder.String())
 				if err != nil {
-					return fmt.Errorf("Failed to process query: %v", err)
+					return fmt.Errorf("Failed to process query: %w", err)
 				}
 				builder.Reset()
 			}


### PR DESCRIPTION
# Description

`cgoase` exits with a non-zero errorcode when encountering errors.

Currently it only exits with `1` on any error. This could be expanded to return different codes based on the error - e.g. `2` for language errors, `3` for protocol errors, etc.pp.

# How was the patch tested?

Manually compiled and run by both me and @fwilhelm92.