### PR TITLE
Configurable maximum length for printed columns

### DIFF
--- a/cmd/cgoase/helpers.go
+++ b/cmd/cgoase/helpers.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"database/sql/driver"
+	"encoding/hex"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -10,6 +12,10 @@ import (
 
 	"github.com/SAP/go-ase/cgo"
 	"github.com/SAP/go-ase/libase/types"
+)
+
+var (
+	fMaxColPrintLength = flag.Int("maxColLength", 50, "Maximum number of characters to print for column")
 )
 
 func process(conn *cgo.Connection, query string) error {
@@ -48,10 +54,17 @@ func process(conn *cgo.Connection, query string) error {
 func processRows(rows *cgo.Rows) error {
 	colNames := rows.Columns()
 
+	colLengths := map[int]int{}
+
 	fmt.Printf("|")
 	for i, colName := range colNames {
-		s := " %-" + strconv.Itoa(int(rows.ColumnTypeMaxLength(i))) + "s |"
+		cellLen := int(rows.ColumnTypeMaxLength(i))
+		if cellLen > *fMaxColPrintLength {
+			cellLen = *fMaxColPrintLength
+		}
+		s := " %-" + strconv.Itoa(cellLen) + "s |"
 		fmt.Printf(s, colName)
+		colLengths[i] = cellLen
 	}
 	fmt.Printf("\n")
 
@@ -72,16 +85,24 @@ func processRows(rows *cgo.Rows) error {
 			return fmt.Errorf("Scanning cells failed: %v", err)
 		}
 
+		fmt.Printf("|")
 		for i, cell := range cells {
-			s := "| %-" + strconv.Itoa(int(rows.ColumnTypeMaxLength(i))) + "v "
-			switch cell.(type) {
-			case *types.Decimal:
+			s := " %-" + strconv.Itoa(colLengths[i]) + "v |"
+			switch rows.ColumnTypeDatabaseTypeName(i) {
+			case "DECIMAL":
 				fmt.Printf(s, cell.(*types.Decimal).String())
+			case "IMAGE":
+				b := hex.EncodeToString(cell.([]byte))
+				if len(b) > colLengths[i] {
+					fmt.Printf(s, b[:colLengths[i]])
+				} else {
+					fmt.Printf(s, b)
+				}
 			default:
 				fmt.Printf(s, (interface{})(cell))
 			}
 		}
-		fmt.Printf("|\n")
+		fmt.Printf("\n")
 	}
 
 	return nil


### PR DESCRIPTION
# Description

Some columns are too long to be appropriately displayed in the terminal.
This PR updates the code to use the type's maximum length until (by
default) 50 characters or the amount the user specified via flag.

Background was @fwilhelm92 writing an integration test that compares the inputs/outputs of of isql and cgoase to verify that the type conversions are correct.

# How was the patch tested?

Manually compiled and tested by @fwilhelm92 and me.
