### PR TITLE
Fix String-Representation of type decimal & output of smallmoney

### DIFF
--- a/cgo/rows.go
+++ b/cgo/rows.go
@@ -227,8 +227,7 @@ func (rows *Rows) Next(dest []driver.Value) error {
 			if err != nil {
 				return fmt.Errorf("Received invalid precision/scale values from ASE: %v", err)
 			}
-
-			dec.SetInt64(int64(binary.LittleEndian.Uint32(bs)))
+			dec.SetInt64(int64(int32(binary.LittleEndian.Uint32(bs))))
 
 			dest[i] = dec
 		case types.DATE:

--- a/cgo/rows.go
+++ b/cgo/rows.go
@@ -227,6 +227,7 @@ func (rows *Rows) Next(dest []driver.Value) error {
 			if err != nil {
 				return fmt.Errorf("Received invalid precision/scale values from ASE: %v", err)
 			}
+
 			dec.SetInt64(int64(int32(binary.LittleEndian.Uint32(bs))))
 
 			dest[i] = dec

--- a/libase/types/decimal.go
+++ b/libase/types/decimal.go
@@ -213,7 +213,7 @@ func (dec *Decimal) SetBytes(b []byte) {
 }
 
 func (dec *Decimal) String() string {
-	s := fmt.Sprintf("%0"+strconv.Itoa(dec.precision)+"s", dec.Int().Abs(dec.i))
+	s := fmt.Sprintf("%0"+strconv.Itoa(dec.precision)+"s", big.NewInt(0).Abs(dec.i))
 
 	neg := ""
 	if dec.IsNegative() {


### PR DESCRIPTION
# Description

1. Previous string-representation of type-decimal values in the ASE did not show negative decimals, due to `*.Abs(dec.i)`. By using a default value to execute `big.NewInt(0).Abs(dec.i)` this issue is fixed (Credits to @ntnn).

2. Negative numbers of ASE-type `smallmoney` are misrepresented:
    - Inserted value:     -999
    - Value displayed:    428497.7296
    - "Explanation":        429496.7295 (maxInt32 without ".") - 999 = 428497.7296

    Thus, the byteslices are misinterpreted, which can be fixed by 'casting' inbetween to `int32` (Credits to @ntnn)

# How was the patch tested?

Manually compiled and tested by @ntnn and me
