### PR TITLE
Decimal better comparison in tests

### DIFF
--- a/libase/types/decimal.go
+++ b/libase/types/decimal.go
@@ -165,7 +165,9 @@ func (dec *Decimal) SetInt64(i int64) {
 
 // Int returns a copy of the underlying big.Int.
 func (dec Decimal) Int() *big.Int {
-	return dec.i
+	i := &big.Int{}
+	i.Add(i, dec.i)
+	return i
 }
 
 func (dec *Decimal) SetBytes(b []byte) {

--- a/libase/types/decimal.go
+++ b/libase/types/decimal.go
@@ -85,44 +85,15 @@ func NewDecimal(precision, scale int) (*Decimal, error) {
 // NewDecimalString creates a new decimal based on the passed string.
 // If the string contains an invalid precision/scale combination an
 // error is returned.
-func NewDecimalString(s string) (*Decimal, error) {
-	s = strings.TrimSpace(s)
-
-	scale := ASEDecimalDefaultScale
-	if strings.Contains(s, ".") {
-		split := strings.SplitN(s, ".", 2)
-		scale = len(split[1])
-	}
-
-	neg := false
-	if s[0] == '-' {
-		neg = true
-	}
-
-	s = strings.TrimLeft(s, "+-")
-
-	split := strings.Split(s, ".")
-	prec := len(split[0]) + scale
-
-	dec, err := NewDecimal(prec, scale)
+func NewDecimalString(precision, scale int, s string) (*Decimal, error) {
+	dec, err := NewDecimal(precision, scale)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating decimal: %w", err)
 	}
 
-	s = split[0]
-	if len(split) == 2 && len(split[1]) > 0 {
-		s += split[1]
-	}
-
-	i := &big.Int{}
-	_, ok := i.SetString(s, 10)
-	if !ok {
-		return nil, fmt.Errorf("Not a valid integer: %s", s)
-	}
-
-	dec.i = i
-	if neg {
-		dec.Negate()
+	err = dec.SetString(s)
+	if err != nil {
+		return nil, fmt.Errorf("error setting string: %w", err)
 	}
 
 	return dec, nil

--- a/libase/types/decimal.go
+++ b/libase/types/decimal.go
@@ -171,13 +171,6 @@ func (dec Decimal) Int() *big.Int {
 }
 
 func (dec *Decimal) SetBytes(b []byte) {
-	if len(b) == 0 {
-		if dec.i != nil {
-			dec.i.SetInt64(0)
-		}
-		return
-	}
-
 	if dec.i == nil {
 		dec.i = &big.Int{}
 	}

--- a/libase/types/decimal_test.go
+++ b/libase/types/decimal_test.go
@@ -1,0 +1,44 @@
+package types
+
+import "testing"
+
+func TestDecimal_SetString(t *testing.T) {
+	testCases := map[string]struct {
+		precision, scale int
+		testString       string
+		expectedErr      error
+	}{
+		"-0.0001":                {precision: 5, scale: 4},
+		"0.0":                    {precision: 2, scale: 1},
+		"1234.5678":              {precision: 8, scale: 4},
+		"1234.05678":             {precision: 9, scale: 5},
+		"1234567890123456789.0":  {precision: 38, scale: 19},
+		"9999999999999999999.0":  {precision: 38, scale: 19},
+		"-1234567890123456789.0": {precision: 38, scale: 19},
+		"-9999999999999999999.0": {precision: 38, scale: 19},
+		"0.1234567890123456789":  {precision: 38, scale: 19},
+		"0.9999999999999999999":  {precision: 38, scale: 19},
+		"-0.1234567890123456789": {precision: 38, scale: 19},
+		"-0.9999999999999999999": {precision: 38, scale: 19},
+	}
+
+	for name, cas := range testCases {
+		t.Run(name,
+			func(t *testing.T) {
+				dec, _ := NewDecimal(cas.precision, cas.scale)
+				err := dec.SetString(name)
+				if err != cas.expectedErr {
+					t.Errorf("Received unexpected error:")
+					t.Errorf("Expected: %w", cas.expectedErr)
+					t.Errorf("Received: %w", err)
+				}
+
+				if dec.String() != name {
+					t.Errorf("Received unexpected string:")
+					t.Errorf("Expected: %s", name)
+					t.Errorf("Received: %s", dec.String())
+				}
+			},
+		)
+	}
+}

--- a/tests/libtest/samples.go
+++ b/tests/libtest/samples.go
@@ -37,16 +37,32 @@ var samplesUnsignedInt = []uint32{0, 1000, 5000, 150000, 123456789, math.MaxUint
 //go:generate go run ./gen_type.go UnsignedSmallInt uint16 -columndef "unsigned smallint"
 var samplesUnsignedSmallInt = []uint16{0, 65535}
 
-//go:generate go run ./gen_type.go Decimal10 github.com/SAP/go-ase/libase/*types.Decimal -columndef decimal(1,0) -convert github.com/SAP/go-ase/libase/types.NewDecimalString -compare compareDecimal
+func convertDecimal10(sample string) (*types.Decimal, error) {
+	return types.NewDecimalString(1, 0, sample)
+}
+
+//go:generate go run ./gen_type.go Decimal10 github.com/SAP/go-ase/libase/*types.Decimal -columndef decimal(1,0) -convert convertDecimal10 -compare compareDecimal
 var samplesDecimal10 = []string{"0", "1", "9"}
 
-//go:generate go run ./gen_type.go Decimal380 github.com/SAP/go-ase/libase/*types.Decimal -columndef decimal(38,0) -convert github.com/SAP/go-ase/libase/types.NewDecimalString -compare compareDecimal
+func convertDecimal380(sample string) (*types.Decimal, error) {
+	return types.NewDecimalString(38, 0, sample)
+}
+
+//go:generate go run ./gen_type.go Decimal380 github.com/SAP/go-ase/libase/*types.Decimal -columndef decimal(38,0) -convert convertDecimal380 -compare compareDecimal
 var samplesDecimal380 = []string{"99999999999999999999999999999999999999"}
 
-//go:generate go run ./gen_type.go Decimal3838 github.com/SAP/go-ase/libase/*types.Decimal -columndef decimal(38,38) -convert github.com/SAP/go-ase/libase/types.NewDecimalString -compare compareDecimal
+func convertDecimal3838(sample string) (*types.Decimal, error) {
+	return types.NewDecimalString(38, 38, sample)
+}
+
+//go:generate go run ./gen_type.go Decimal3838 github.com/SAP/go-ase/libase/*types.Decimal -columndef decimal(38,38) -convert convertDecimal3838 -compare compareDecimal
 var samplesDecimal3838 = []string{".99999999999999999999999999999999999999"}
 
-//go:generate go run ./gen_type.go Decimal github.com/SAP/go-ase/libase/*types.Decimal -columndef "decimal(38,19)" -convert github.com/SAP/go-ase/libase/types.NewDecimalString -compare compareDecimal
+func convertDecimal3819(sample string) (*types.Decimal, error) {
+	return types.NewDecimalString(38, 19, sample)
+}
+
+//go:generate go run ./gen_type.go Decimal github.com/SAP/go-ase/libase/*types.Decimal -columndef "decimal(38,19)" -convert convertDecimal3819 -compare compareDecimal
 var samplesDecimal = []string{
 	// ASE max
 	"1234567890123456789",
@@ -79,7 +95,11 @@ var samplesReal = []float64{
 	math.MaxFloat32,
 }
 
-//go:generate go run ./gen_type.go Money github.com/SAP/go-ase/libase/*types.Decimal -convert github.com/SAP/go-ase/libase/types.NewDecimalString -compare compareDecimal
+func convertMoney(sample string) (*types.Decimal, error) {
+	return types.NewDecimalString(types.ASEMoneyPrecision, types.ASEMoneyScale, sample)
+}
+
+//go:generate go run ./gen_type.go Money github.com/SAP/go-ase/libase/*types.Decimal -convert convertMoney -compare compareDecimal
 var samplesMoney = []string{
 	// ASE min
 	"-922337203685477.5807",
@@ -91,7 +111,11 @@ var samplesMoney = []string{
 	"1234.5678",
 }
 
-//go:generate go run ./gen_type.go Money4 github.com/SAP/go-ase/libase/*types.Decimal -columndef smallmoney -convert github.com/SAP/go-ase/libase/types.NewDecimalString -compare compareDecimal
+func convertSmallMoney(sample string) (*types.Decimal, error) {
+	return types.NewDecimalString(types.ASESmallMoneyPrecision, types.ASESmallMoneyScale, sample)
+}
+
+//go:generate go run ./gen_type.go Money4 github.com/SAP/go-ase/libase/*types.Decimal -columndef smallmoney -convert convertSmallMoney -compare compareDecimal
 var samplesMoney4 = []string{
 	// ASE min
 	"-214748.3648",

--- a/tests/libtest/samples.go
+++ b/tests/libtest/samples.go
@@ -65,10 +65,7 @@ var samplesDecimal = []string{
 }
 
 func compareDecimal(recv, expect *types.Decimal) bool {
-	if recv.String() != expect.String() {
-		return true
-	}
-	return false
+	return !expect.Cmp(*recv)
 }
 
 //go:generate go run ./gen_type.go Float float64

--- a/tests/libtest/type_decimal.go
+++ b/tests/libtest/type_decimal.go
@@ -21,7 +21,7 @@ func testDecimal(t *testing.T, db *sql.DB, tableName string) {
 	for i, sample := range samplesDecimal {
 
 		// Convert sample with passed function before proceeding
-		mySample, err := types.NewDecimalString(sample)
+		mySample, err := convertDecimal3819(sample)
 		if err != nil {
 			t.Errorf("Failed to convert sample %v: %v", sample, err)
 			return

--- a/tests/libtest/type_decimal10.go
+++ b/tests/libtest/type_decimal10.go
@@ -21,7 +21,7 @@ func testDecimal10(t *testing.T, db *sql.DB, tableName string) {
 	for i, sample := range samplesDecimal10 {
 
 		// Convert sample with passed function before proceeding
-		mySample, err := types.NewDecimalString(sample)
+		mySample, err := convertDecimal10(sample)
 		if err != nil {
 			t.Errorf("Failed to convert sample %v: %v", sample, err)
 			return

--- a/tests/libtest/type_decimal380.go
+++ b/tests/libtest/type_decimal380.go
@@ -21,7 +21,7 @@ func testDecimal380(t *testing.T, db *sql.DB, tableName string) {
 	for i, sample := range samplesDecimal380 {
 
 		// Convert sample with passed function before proceeding
-		mySample, err := types.NewDecimalString(sample)
+		mySample, err := convertDecimal380(sample)
 		if err != nil {
 			t.Errorf("Failed to convert sample %v: %v", sample, err)
 			return

--- a/tests/libtest/type_decimal3838.go
+++ b/tests/libtest/type_decimal3838.go
@@ -21,7 +21,7 @@ func testDecimal3838(t *testing.T, db *sql.DB, tableName string) {
 	for i, sample := range samplesDecimal3838 {
 
 		// Convert sample with passed function before proceeding
-		mySample, err := types.NewDecimalString(sample)
+		mySample, err := convertDecimal3838(sample)
 		if err != nil {
 			t.Errorf("Failed to convert sample %v: %v", sample, err)
 			return

--- a/tests/libtest/type_money.go
+++ b/tests/libtest/type_money.go
@@ -21,7 +21,7 @@ func testMoney(t *testing.T, db *sql.DB, tableName string) {
 	for i, sample := range samplesMoney {
 
 		// Convert sample with passed function before proceeding
-		mySample, err := types.NewDecimalString(sample)
+		mySample, err := convertMoney(sample)
 		if err != nil {
 			t.Errorf("Failed to convert sample %v: %v", sample, err)
 			return

--- a/tests/libtest/type_money4.go
+++ b/tests/libtest/type_money4.go
@@ -21,7 +21,7 @@ func testMoney4(t *testing.T, db *sql.DB, tableName string) {
 	for i, sample := range samplesMoney4 {
 
 		// Convert sample with passed function before proceeding
-		mySample, err := types.NewDecimalString(sample)
+		mySample, err := convertSmallMoney(sample)
 		if err != nil {
 			t.Errorf("Failed to convert sample %v: %v", sample, err)
 			return


### PR DESCRIPTION
# Description

@fwilhelm92 found displaying issues which were fixed in #56. While investigating these issues we found that the integration tests were using the string output to compare the sample decimal and the decimal read from ASE.
That these issues didn't occur in the tests stemmed from both the sample and the read decimal being passed through the same erroneous error path.

Originally I chose to compare by string because the sample decimal is generated with precision and scale set to match exactly the required sample - while the decimal read from ASE has the precision and scale set to the column constraints.
This resulted in the two decimal looking the same when printed but entirely different on a member basis - causing the `.Cmp` method, which compared the precision, scale and underlying big.Int, to fail.

This PR changes the generation for sample decimals in the tests to use the same precision and scale, allowing to use the more correct `.Cmp` method to compare the generated sample decimal and the read ASE decimal.

# How was the patch tested?

Manually and using `make integration`.
