### PR TITLE
Add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # go-ase
 
+
+[![API reference](https://img.shields.io/badge/godoc-reference-5272B4)](https://pkg.go.dev/github.com/SAP/go-ase)
+[![Go Report Card](https://goreportcard.com/badge/github.com/SAP/go-ase)](https://goreportcard.com/report/github.com/SAP/go-ase)
+
 ## Description
 
 `go-ase` is a driver for the [`databasq/sql`][pkg-database-sql] package


### PR DESCRIPTION
# Description

Adds godoc and goreport badges to the readme.

The godoc badge from shield.io is a suggestion here: https://github.com/golang/go/issues/36982#issuecomment-630987917
Once go.pkg.dev provides an official badge we can switch to that - I'm subscribed to the issue.

# How was the patch tested?

-