### PR TITLE
Add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+---
+version: 2
+
+updates:
+
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - "SAP/go-ase-team"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    reviewers:
+      - "SAP/go-ase-team"


### PR DESCRIPTION
# Description

Adds a dependabot config file to automatically create PRs to update github actions and go modules:
https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates

# How was the patch tested?

https://github.com/ntnn/go-ase/network/updates
The github actions check there is failing because I don't have the actions in my master branch.
