### PR TITLE
Print changed files and diff in generate job and work on all pushes/manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           make generate
           if [ "$(git status --porcelain | wc -l)" -ne 0 ]; then
             printf '::error ::%s' '`make generate` left or changed files'
+            git status
+            git diff
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,9 @@
 name: CI
 
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
+  push: {}
   pull_request: {}
+  workflow_dispatch: {}
 
 jobs:
   golangci-lint:


### PR DESCRIPTION
# Description

I've noticed that it'd be quite handy to have actions run on all branches/pushes to check suite errors before making a PR (see e.g. https://github.com/SAP/go-ase/pull/66 were I've had to update the PR repeatedly to get golangci-lint to work).

The additional output in the generate job is merely information to see if the changed generation is related to the PR itself.

# How was the patch tested?

https://github.com/SAP/go-ase/pull/66
https://github.com/ntnn/go-ase/actions
