### PR TITLE
Fix golangci-lint failing to set up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,34 @@ on:
   pull_request: {}
 
 jobs:
-  golangci-lint:
+
+  # golangci-lint-action will fail if setup-go is called before it - but
+  # to get the list of packages to lint go for `go list` is needed.
+  golangci-lint-pre:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-      - name: lint-dirs
-        run: |
-          printf '::set-output out="%s"' "$(make lint-dirs)"
+      - id: lint-dirs
+        run: echo "::set-output name=lint-dirs::$(make lint-dirs)"
+    outputs:
+      lint-dirs: ${{ steps.lint-dirs.outputs.lint-dirs }}
+
+  golangci-lint:
+    runs-on: ubuntu-latest
+    needs: golangci-lint-pre
+    steps:
+      - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.28
           # Restrict golangci-lint to run against chosen directories.
           # Otherwise golangci-lint attempts to lint files it cannot
           # process, such as cgo code.
-          args: ${{ steps.lint-dirs.output }}
+          args: ${{ needs.golangci-lint-pre.outputs.lint-dirs }}
           # github.head_ref is only set on pull_request runs, not for
           # tags or branches.
-          # For commits on master and tags all issues are reported, but
+          # For commits on branches and tags all issues are reported, but
           # PR runs only report new issues introduced in the PR.
           only-new-issues: ${{ github.head_ref != '' }}
 
@@ -49,5 +59,4 @@ jobs:
       - uses: actions/setup-go@v2
       - uses: actions/checkout@v2
       - run: |
-          go mod download
           make test-go


### PR DESCRIPTION
# Description

`golangci-lint-action` fails to set up when `setup-go` is called before it:
https://github.com/SAP/go-ase/runs/905510224?check_suite_focus=true

Instead a new job `golangci-lint-pre` gets the list of directories, which is then passed to `golangci-lint` through the needs context.

# How was the patch tested?

https://github.com/ntnn/go-ase/runs/906067079?check_suite_focus=true