### PR TITLE
Fix linting issues

### DIFF
--- a/libase/capability/defaultVersion_test.go
+++ b/libase/capability/defaultVersion_test.go
@@ -1,5 +1,7 @@
 package capability
 
+import "log"
+
 var (
 	ExampleVersionCapOtherthing   = NewCapability("otherthing", "1.5.0")
 	ExampleVersionBug50           = NewCapability("bug reported in ticket #50", "0.1.0", "0.2.0", "0.9.0", "1.1.0")
@@ -30,11 +32,11 @@ type ExampleSatisfyInterface struct {
 
 // Connect connects to the server, stores the server version in the
 // struct and calls the targets SetCapabilities
-func (v *ExampleSatisfyInterface) Connect() {
+func (v *ExampleSatisfyInterface) Connect() error {
 	v.ServerVersion = "1.0.5"
 
 	// Set capabilities based on server version
-	ExampleVersionTarget.SetCapabilities(v)
+	return ExampleVersionTarget.SetCapabilities(v)
 }
 
 func (v ExampleSatisfyInterface) VersionString() string {
@@ -61,7 +63,11 @@ func (v ExampleSatisfyInterface) Has(cap *Capability) bool {
 func ExampleVersion() {
 	// Create connection to server and connect
 	connection := &ExampleSatisfyInterface{}
-	connection.Connect()
+	err := connection.Connect()
+	if err != nil {
+		log.Printf("Error setting up example connection: %v", err)
+		return
+	}
 
 	// Perform actions against server
 	connection.Do("something")

--- a/libase/libdsn/dsn_test.go
+++ b/libase/libdsn/dsn_test.go
@@ -134,7 +134,7 @@ func TestDsnInfo_AsSimple(t *testing.T) {
 				Username: "user",
 				Password: "passwd",
 			},
-			expected: "host='hostname' pass='passwd' port='4901' user='user'",
+			expected: "host='hostname' password='passwd' port='4901' username='user'",
 		},
 		"Everything": {
 			dsn: DsnInfo{
@@ -149,7 +149,7 @@ func TestDsnInfo_AsSimple(t *testing.T) {
 					"baz": []string{""},
 				},
 			},
-			expected: "db='db_example' host='hostname' pass='passwd' port='4901' user='user' bar='baz' baz='' foo='bar'",
+			expected: "database='db_example' host='hostname' password='passwd' port='4901' username='user' bar='baz' baz='' foo='bar'",
 		},
 	}
 

--- a/libase/types/main.go
+++ b/libase/types/main.go
@@ -81,11 +81,11 @@ func (conv ValueConverter) ConvertValue(v interface{}) (driver.Value, error) {
 		return v, nil
 	}
 
-	switch v.(type) {
+	switch value := v.(type) {
 	case int:
-		return int64(v.(int)), nil
+		return int64(value), nil
 	case uint:
-		return uint64(v.(uint)), nil
+		return uint64(value), nil
 	}
 
 	sv := reflect.TypeOf(v)

--- a/tests/libtest/samples.go
+++ b/tests/libtest/samples.go
@@ -181,15 +181,6 @@ var samplesBigTime = []time.Time{
 	time.Date(1, time.January, 1, 23, 59, 59, 999999000, time.UTC),
 }
 
-func convertDuration(s string) (time.Time, error) {
-	d, err := time.ParseDuration(s)
-	if err != nil {
-		return time.Time{}, err
-	}
-
-	return time.Time{}.Add(d), nil
-}
-
 //go:generate go run ./gen_type.go VarChar string -columndef varchar(13) -compare compareChar
 // TODO: -null database/sql.NullString
 var samplesVarChar = samplesChar

--- a/tests/libtest/samples.go
+++ b/tests/libtest/samples.go
@@ -213,7 +213,7 @@ var samplesBinary = [][]byte{
 var samplesVarBinary = samplesBinary
 
 func compareBinary(recv, expect []byte) bool {
-	return bytes.Compare(bytes.Trim(recv, "\x00"), expect) != 0
+	return !bytes.Equal(bytes.Trim(recv, "\x00"), expect)
 }
 
 //go:generate go run ./gen_type.go Bit bool


### PR DESCRIPTION
# Description

`golangci-lint` found a couple overlooked issues. This PR fixes those.

There are still two remaining issues - an unused variable and an unused enum.
Those will be required once we get further with the pure go implementation, as such we'll leave them for now.
Those issues won't be a problem for PRs as the linting action only acts on new issues - this will only show up in tests for branches.

# How was the patch tested?

`make lint` and `make test`.
