### PR TITLE
Fix reading commands from stdin for cgoase/goase

### DIFF
--- a/libase/term/parse.go
+++ b/libase/term/parse.go
@@ -35,5 +35,12 @@ func ParseAndExecQueries(db *sql.DB, line string) error {
 		}
 	}
 
+	if builder.String() != "" {
+		err := process(db, builder.String())
+		if err != nil {
+			return fmt.Errorf("term: failed to process query: %w", err)
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
# Description

Running e.g. `goase 'select * from table'` doesn't yield any output as the repl code exits directly after `io.EOF`.
Additionally the parsing code discarded the last statement in a passed line.

This worked in an interactive repl as here the command line didn't actually submit any statements until the last character overall is a semicolon.

# How was the patch tested?

`make lint` and `make test`.