### PR TITLE
Do not pass TDS_EED with TDS_EED_INFO to library consumers

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -215,6 +215,17 @@ func (tdsChan *Channel) handleSpecialPackage(pkg Package) (bool, error) {
 		return false, nil
 	}
 
+	if eed, ok := pkg.(*EEDPackage); ok {
+		// TDS_EED_INFO packages are not supposed to leave the client
+		// library.
+		if eed.Status|TDS_EED_INFO == TDS_EED_INFO {
+			return false, nil
+		}
+
+		// TODO handle TDS_EED_INFO
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/libase/tds/login.go
+++ b/libase/tds/login.go
@@ -282,24 +282,6 @@ func (tdsChan *Channel) Login(ctx context.Context, config *LoginConfig) error {
 		return fmt.Errorf("error sending login payload: %w", err)
 	}
 
-	// EED encoding
-	_, err = tdsChan.NextPackage(true)
-	if err != nil {
-		return fmt.Errorf("error reading EED package: %w", err)
-	}
-
-	// EED database change
-	_, err = tdsChan.NextPackage(true)
-	if err != nil {
-		return fmt.Errorf("error reading EED package: %w", err)
-	}
-
-	// EED language
-	_, err = tdsChan.NextPackage(true)
-	if err != nil {
-		return fmt.Errorf("error reading EED package: %w", err)
-	}
-
 	pkg, err = tdsChan.NextPackage(true)
 	if err != nil {
 		return fmt.Errorf("error reading LoginAck package: %w", err)


### PR DESCRIPTION
# Description

TDS_EED packages with TDS_EED_INFO should not be passed to the consumers.

# How was the patch tested?

`make test` and `make integration`.
