### PR TITLE
Simplify ReturnStatusPackage.WriteTo

### DIFF
--- a/libase/tds/packageReturnStatus.go
+++ b/libase/tds/packageReturnStatus.go
@@ -20,12 +20,7 @@ func (pkg *ReturnStatusPackage) ReadFrom(ch BytesChannel) error {
 }
 
 func (pkg ReturnStatusPackage) WriteTo(ch BytesChannel) error {
-	err := ch.WriteInt32(pkg.returnValue)
-	if err != nil {
-		return fmt.Errorf("error writing return value: %w", err)
-	}
-
-	return nil
+	return ch.WriteInt32(pkg.returnValue)
 }
 
 func (pkg ReturnStatusPackage) ReturnValue() int {


### PR DESCRIPTION
# Description

The `.WriteTo` errors should only return the errors directly instead of adding context.
If an error occurs while writing bytes to the `BytesChannel` the error is either below in the code implementing `BytesChannel` or a handling errors further up.

# How was the patch tested?

`make test` and `make integration`.