### PR TITLE
Export DonePackage members

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -190,14 +190,14 @@ func (tdsChan Channel) Logout() error {
 		return fmt.Errorf("expected done package in logout response, got: %v", pkg)
 	}
 
-	if done.status|TDS_DONE_FINAL != TDS_DONE_FINAL {
+	if done.Status&TDS_DONE_FINAL != TDS_DONE_FINAL {
 		return fmt.Errorf("received done package with status %s instead of TDS_DONE_FINAL",
-			done.status)
+			done.Status)
 	}
 
-	if done.tranState|TDS_TRAN_COMPLETED != TDS_TRAN_COMPLETED {
+	if done.TranState&TDS_TRAN_COMPLETED != TDS_TRAN_COMPLETED {
 		return fmt.Errorf("received done package with transtate %s instead of TDS_TRAN_COMPLETED",
-			done.tranState)
+			done.TranState)
 	}
 
 	return nil

--- a/libase/tds/login.go
+++ b/libase/tds/login.go
@@ -80,7 +80,7 @@ func (tdsChan *Channel) Login(ctx context.Context, config *LoginConfig) error {
 			return fmt.Errorf("expected Done as second response, received: %v", pkg)
 		}
 
-		if done.status != TDS_DONE_FINAL {
+		if done.Status&TDS_DONE_FINAL != TDS_DONE_FINAL {
 			return fmt.Errorf("expected DONE(FINAL), received: %s", done)
 		}
 
@@ -319,14 +319,14 @@ func (tdsChan *Channel) Login(ctx context.Context, config *LoginConfig) error {
 		return fmt.Errorf("expected done package, received %T instead: %v", pkg, pkg)
 	}
 
-	if done.status != TDS_DONE_FINAL {
+	if done.Status&TDS_DONE_FINAL != TDS_DONE_FINAL {
 		return fmt.Errorf("expected done package with status TDS_DONE_FINAL, received %s",
-			done.status)
+			done.Status)
 	}
 
-	if done.tranState != TDS_TRAN_COMPLETED {
+	if done.TranState&TDS_TRAN_COMPLETED != TDS_TRAN_COMPLETED {
 		return fmt.Errorf("expected done package with transtate TDS_TRAN_COMPLETED, received %s",
-			done.tranState)
+			done.TranState)
 	}
 
 	tdsChan.Reset()

--- a/libase/tds/packageDone.go
+++ b/libase/tds/packageDone.go
@@ -31,9 +31,9 @@ const (
 )
 
 type DonePackage struct {
-	status    DoneState
-	tranState TransState
-	count     int32
+	Status    DoneState
+	TranState TransState
+	Count     int32
 }
 
 type DoneProcPackage struct{ DonePackage }
@@ -44,15 +44,15 @@ func (pkg *DonePackage) ReadFrom(ch BytesChannel) error {
 	if err != nil {
 		return ErrNotEnoughBytes
 	}
-	pkg.status = DoneState(status)
+	pkg.Status = DoneState(status)
 
 	tranState, err := ch.Uint16()
 	if err != nil {
 		return ErrNotEnoughBytes
 	}
-	pkg.tranState = TransState(tranState)
+	pkg.TranState = TransState(tranState)
 
-	pkg.count, err = ch.Int32()
+	pkg.Count, err = ch.Int32()
 	if err != nil {
 		return ErrNotEnoughBytes
 	}
@@ -66,25 +66,21 @@ func (pkg DonePackage) WriteTo(ch BytesChannel) error {
 		return err
 	}
 
-	err = ch.WriteUint16(uint16(pkg.status))
+	err = ch.WriteUint16(uint16(pkg.Status))
 	if err != nil {
 		return err
 	}
 
-	err = ch.WriteUint16(uint16(pkg.tranState))
+	err = ch.WriteUint16(uint16(pkg.TranState))
 	if err != nil {
 		return err
 	}
 
-	if pkg.status|TDS_DONE_COUNT == TDS_DONE_COUNT {
-		return ch.WriteInt32(pkg.count)
-	}
-
-	return nil
+	return ch.WriteInt32(pkg.Count)
 }
 
 func (pkg DonePackage) String() string {
-	stati := deBitmask(int(pkg.status), int(TDS_DONE_CUMULATIVE))
+	stati := deBitmask(int(pkg.Status), int(TDS_DONE_CUMULATIVE))
 	strStati := ""
 	if len(stati) == 0 {
 		strStati = TDS_DONE_FINAL.String()
@@ -97,7 +93,7 @@ func (pkg DonePackage) String() string {
 		}
 	}
 
-	transi := deBitmask(int(pkg.tranState), int(TDS_TRAN_STMT_FAIL))
+	transi := deBitmask(int(pkg.TranState), int(TDS_TRAN_STMT_FAIL))
 	strTransi := ""
 	if len(transi) == 0 {
 		strTransi = TDS_NOT_IN_TRAN.String()


### PR DESCRIPTION
# Description

Export members of `DonePackage`. Will be required for other packages to set them before sending off to a TDS server.
This also fixes a few comparisons in the code where the members are used.

# How was the patch tested?

`make test` and `make integration`.
