### PR TITLE
Add message number to handle

### DIFF
--- a/cmd/cgoase/main.go
+++ b/cmd/cgoase/main.go
@@ -47,5 +47,5 @@ func handleMessage(msg cgo.Message) {
 		return
 	}
 
-	log.Println(msg.Content())
+	log.Printf("Msg %d: %s", msg.MessageNumber(), msg.Content())
 }


### PR DESCRIPTION
# Description

Adds the message number in the log output of `cgoase`.

# How was the patch tested?

Manual.
