### PR TITLE
libase/types fixes

### DIFF
--- a/libase/types/bytes.go
+++ b/libase/types/bytes.go
@@ -101,5 +101,12 @@ func (t DataType) Bytes(endian binary.ByteOrder, value interface{}) ([]byte, err
 	if err != nil {
 		return nil, fmt.Errorf("error writing value: %w", err)
 	}
-	return buf.Bytes(), nil
+
+	bs := buf.Bytes()
+	if t.ByteSize() != -1 && t.ByteSize() != len(bs) {
+		return nil, fmt.Errorf("binary.Write returned a byteslice of length %d, expected %d for datatype %s",
+			len(bs), t.ByteSize(), t)
+	}
+
+	return bs, nil
 }

--- a/libase/types/convert.go
+++ b/libase/types/convert.go
@@ -1,0 +1,73 @@
+package types
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+)
+
+func (t DataType) ConvertValue(v interface{}) (driver.Value, error) {
+	sv := reflect.ValueOf(v)
+
+	// Return value as-is if the type already matches.
+	if sv.Type() == ReflectTypes[t] {
+		return v, nil
+	}
+
+	switch t {
+	case INT1:
+		switch sv.Kind() {
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+			return uint8(sv.Int()), nil
+		}
+	case INT2:
+		switch sv.Kind() {
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+			return int16(sv.Int()), nil
+		}
+	case INT4:
+		switch sv.Kind() {
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+			return int32(sv.Int()), nil
+		}
+	case INT8, INTN:
+		switch sv.Kind() {
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+			return sv.Int(), nil
+		}
+	case UINT2:
+		switch sv.Kind() {
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+			return uint16(sv.Uint()), nil
+		}
+	case UINT4:
+		switch sv.Kind() {
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+			return uint32(sv.Uint()), nil
+		}
+	case UINT8, UINTN:
+		switch sv.Kind() {
+		case reflect.Int, reflect.Int64, reflect.Int32, reflect.Int16, reflect.Int8,
+			reflect.Uint64, reflect.Uint32, reflect.Uint16, reflect.Uint8:
+			return sv.Uint(), nil
+		}
+	case FLT4:
+		switch sv.Kind() {
+		case reflect.Float64:
+			return float32(sv.Float()), nil
+		}
+	case FLT8:
+		switch sv.Kind() {
+		case reflect.Float32:
+			return sv.Float(), nil
+		}
+	}
+
+	return nil, fmt.Errorf("cannot convert %v (type %T) for %s", v, v, t)
+}

--- a/libase/types/goValue.go
+++ b/libase/types/goValue.go
@@ -95,11 +95,10 @@ func (t DataType) goValue(endian binary.ByteOrder, bs []byte) (interface{}, erro
 			return nil, fmt.Errorf("invalid length for FLTN: %d", len(bs))
 		}
 	case BIT:
-		bit := false
 		if bs[0] == 0x1 {
-			bit = true
+			return true, nil
 		}
-		return bit, nil
+		return false, nil
 	case LONGBINARY, BINARY, IMAGE:
 		// Noop
 		return bs, nil

--- a/libase/types/goValue.go
+++ b/libase/types/goValue.go
@@ -33,7 +33,7 @@ func (t DataType) goValue(endian binary.ByteOrder, bs []byte) (interface{}, erro
 
 	switch t {
 	case INT1:
-		var x int8
+		var x uint8
 		err := binary.Read(buffer, endian, &x)
 		return x, err
 	case INT2:

--- a/libase/types/goValue.go
+++ b/libase/types/goValue.go
@@ -83,6 +83,17 @@ func (t DataType) goValue(endian binary.ByteOrder, bs []byte) (interface{}, erro
 		var x float64
 		err := binary.Read(buffer, endian, &x)
 		return x, err
+	case FLTN:
+		switch len(bs) {
+		case 0:
+			return 0, nil
+		case 4:
+			return FLT4.GoValue(endian, bs)
+		case 8:
+			return FLT8.GoValue(endian, bs)
+		default:
+			return nil, fmt.Errorf("invalid length for FLTN: %d", len(bs))
+		}
 	case BIT:
 		bit := false
 		if bs[0] == 0x1 {

--- a/libase/types/reflectType.go
+++ b/libase/types/reflectType.go
@@ -26,7 +26,7 @@ var ReflectTypes = map[DataType]reflect.Type{
 	FLT8:         reflect.TypeOf(float64(0)),
 	FLTN:         reflect.TypeOf(float64(0)),
 	IMAGE:        reflect.SliceOf(reflect.TypeOf(byte(0))),
-	INT1:         reflect.TypeOf(int8(0)),
+	INT1:         reflect.TypeOf(uint8(0)),
 	INT2:         reflect.TypeOf(int16(0)),
 	INT4:         reflect.TypeOf(int32(0)),
 	INT8:         reflect.TypeOf(int64(0)),

--- a/libase/types/reflectType.go
+++ b/libase/types/reflectType.go
@@ -38,7 +38,7 @@ var ReflectTypes = map[DataType]reflect.Type{
 	NUMN:         reflect.TypeOf(&Decimal{}),
 	SENSITIVITY:  nil,
 	SHORTDATE:    reflect.TypeOf(time.Time{}),
-	SHORTMONEY:   reflect.TypeOf(time.Time{}),
+	SHORTMONEY:   reflect.TypeOf(&Decimal{}),
 	TEXT:         reflect.TypeOf(string("")),
 	TIME:         reflect.TypeOf(time.Time{}),
 	TIMEN:        reflect.TypeOf(time.Time{}),

--- a/libase/types/reflectType.go
+++ b/libase/types/reflectType.go
@@ -22,7 +22,7 @@ var ReflectTypes = map[DataType]reflect.Type{
 	DATETIME:     reflect.TypeOf(time.Time{}),
 	DATETIMEN:    reflect.TypeOf(time.Time{}),
 	DECN:         reflect.TypeOf(&Decimal{}),
-	FLT4:         reflect.TypeOf(float64(0)),
+	FLT4:         reflect.TypeOf(float32(0)),
 	FLT8:         reflect.TypeOf(float64(0)),
 	FLTN:         reflect.TypeOf(float64(0)),
 	IMAGE:        reflect.SliceOf(reflect.TypeOf(byte(0))),

--- a/libase/types/valueConverter.go
+++ b/libase/types/valueConverter.go
@@ -12,7 +12,7 @@ import (
 
 type ValueConverter struct{}
 
-var DefaultValueConverter = ValueConverter{}
+var DefaultValueConverter ValueConverter
 
 func (conv ValueConverter) ConvertValue(v interface{}) (driver.Value, error) {
 	// Check the default value converter
@@ -26,8 +26,6 @@ func (conv ValueConverter) ConvertValue(v interface{}) (driver.Value, error) {
 		return int64(value), nil
 	case uint:
 		return uint64(value), nil
-	case uint8:
-		return int8(value), nil
 	}
 
 	// Check the reflect types if the value is handled.


### PR DESCRIPTION
# Description

Fixes for some errors that were introduced when switching libase/types from Client-Library to TDS-based types.

# How was the patch tested?

`make test` and `make integration` - although with changes from the coming PRs.