### PR TITLE
Adjust colLength for Image; Adjust var formatting

### DIFF
--- a/cgo/rows.go
+++ b/cgo/rows.go
@@ -82,7 +82,7 @@ func newRows(cmd *Command) (*Rows, error) {
 		asetype := (ASEType)(r.dataFmts[i].datatype)
 		if asetype.String() == "" {
 			r.Close()
-			return nil, fmt.Errorf("Invalid ASEType: %w", r.dataFmts[i].datatype)
+			return nil, fmt.Errorf("Invalid ASEType: %v", r.dataFmts[i].datatype)
 		}
 
 		r.colASEType[i] = asetype
@@ -128,7 +128,7 @@ func (rows *Rows) Close() error {
 		}
 
 		if r != nil {
-			return fmt.Errorf("Received rows reading results, exiting: %w", r)
+			return fmt.Errorf("Received rows reading results, exiting: %v", r)
 		}
 	}
 
@@ -262,7 +262,7 @@ func (rows *Rows) ColumnTypePrecisionScale(index int) (int64, int64, bool) {
 
 func (rows *Rows) ColumnTypeLength(index int) (int64, bool) {
 	switch rows.colASEType[index] {
-	case BINARY:
+	case BINARY, IMAGE:
 		return int64(rows.dataFmts[index].maxlength), true
 	case CHAR:
 		return int64(C.CS_MAX_CHAR), true

--- a/cgo/statement.go
+++ b/cgo/statement.go
@@ -311,7 +311,7 @@ func (stmt *statement) exec(args []driver.NamedValue) error {
 
 		retval = C.ct_param(stmt.cmd.cmd, datafmt, ptr, csDatalen, 0)
 		if retval != C.CS_SUCCEED {
-			return makeError(retval, "C.ct_param on parameter %d failed with argument '%w'", i, arg)
+			return makeError(retval, "C.ct_param on parameter %d failed with argument '%v'", i, arg)
 		}
 	}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

# Description

- The output of the datatype image using cgo was trimmed to the column-length of the column-name. Thus, the column-length was adjusted. 
- Variable formatting was adjusted.

# How was the patch tested?

Manual, `make test`
