### PR TITLE
Skip EEDError

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -329,6 +329,13 @@ func (tdsChan *Channel) NextPackageUntil(ctx context.Context, wait bool, process
 
 		ok, err := processPkg(pkg)
 		if err != nil {
+			err = fmt.Errorf("error in user-defined processing function: %w", err)
+
+			// Only return an EEDError if there were EEDPackages
+			if len(eedError.EEDPackages) == 0 {
+				return nil, err
+			}
+
 			eedError.WrappedError = err
 			return nil, eedError
 		}


### PR DESCRIPTION
# Description

Skip the EEDError when no EEDPackages are available.

# How was the patch tested?

`make integration`.