### PR TITLE
Modify datatype float in cgo

### DIFF
--- a/cgo/types.go
+++ b/cgo/types.go
@@ -48,7 +48,7 @@ func (t ASEType) ToDataType() types.DataType {
 	case DECIMAL:
 		return types.DECN
 	case FLOAT:
-		return types.FLT4
+		return types.FLT8
 	case IMAGE:
 		return types.IMAGE
 	case IMAGELOCATOR:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

# Description

Data of Float-datatype was not returned correctly (found by @ntnn). Changing the Float-datatype to `FLT8` (8-byte float type) fixes the problem.

# How was the patch tested?

`make test`, manually
