### PR TITLE
Unify reading results for TDS_LANGUAGE and TDS_DYNAMIC{,2}

### DIFF
--- a/libase/tds/packageDone.go
+++ b/libase/tds/packageDone.go
@@ -40,8 +40,8 @@ type DonePackage struct {
 	Count     int32
 }
 
-type DoneProcPackage struct{ DonePackage }
-type DoneInProcPackage struct{ DonePackage }
+type DoneProcPackage = DonePackage
+type DoneInProcPackage = DonePackage
 
 func (pkg *DonePackage) ReadFrom(ch BytesChannel) error {
 	status, err := ch.Uint16()

--- a/purego/genericExec.go
+++ b/purego/genericExec.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
+
+	"github.com/SAP/go-ase/libase/tds"
 )
 
 func (c *Conn) GenericExec(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, driver.Result, error) {
@@ -34,6 +36,47 @@ func (c *Conn) GenericExec(ctx context.Context, query string, args []driver.Name
 	rows, result, err := stmt.exec(ctx, args)
 	if err != nil {
 		return nil, nil, fmt.Errorf("go-ase: error executing dynamic SQL: %w", err)
+	}
+
+	return rows, result, nil
+}
+
+func (c *Conn) genericResults(ctx context.Context) (driver.Rows, driver.Result, error) {
+	rows := &Rows{Conn: c}
+	result := &Result{}
+
+	_, err := c.Channel.NextPackageUntil(ctx, true,
+		func(pkg tds.Package) (bool, error) {
+			switch typed := pkg.(type) {
+			case *tds.RowFmtPackage:
+				rows.RowFmt = typed
+				return true, nil
+			case *tds.DonePackage:
+				if typed.Status&tds.TDS_DONE_COUNT == tds.TDS_DONE_COUNT {
+					result.rowsAffected = int64(typed.Count)
+				}
+
+				if typed.Status&tds.TDS_DONE_MORE == tds.TDS_DONE_MORE {
+					return false, nil
+				}
+
+				if typed.Status&tds.TDS_DONE_PROC == tds.TDS_DONE_PROC || typed.Status&tds.TDS_DONE_FINAL == tds.TDS_DONE_FINAL {
+					return true, nil
+				}
+
+				return false, fmt.Errorf("%T does not have status TDS_DONE_COUNT or TDS_DONE_FINAL set: %s",
+					typed, typed)
+			default:
+				return false, fmt.Errorf("unhandled package type %T", typed)
+			}
+		},
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if rows.RowFmt == nil {
+		return nil, result, nil
 	}
 
 	return rows, result, nil

--- a/purego/language.go
+++ b/purego/language.go
@@ -7,7 +7,6 @@ package purego
 import (
 	"context"
 	"database/sql/driver"
-	"errors"
 	"fmt"
 
 	"github.com/SAP/go-ase/libase/tds"
@@ -24,37 +23,5 @@ func (c Conn) language(ctx context.Context, query string) (driver.Rows, driver.R
 		return nil, nil, fmt.Errorf("error sending language command: %w", err)
 	}
 
-	for {
-		pkg, err := c.Channel.NextPackageUntil(ctx, true,
-			func(pkg tds.Package) (bool, error) {
-				switch typed := pkg.(type) {
-				case *tds.RowFmtPackage:
-					return true, nil
-				case *tds.DonePackage:
-					if typed.Status&tds.TDS_DONE_ERRROR == tds.TDS_DONE_ERRROR {
-						return false, errors.New("received Done with error, transaction aborted")
-					}
-					return true, nil
-				default:
-					return false, nil
-				}
-			},
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		switch typed := pkg.(type) {
-		case *tds.RowFmtPackage:
-			return &Rows{Conn: &c, RowFmt: typed}, nil, nil
-		case *tds.DonePackage:
-			result := &Result{}
-			if typed.Status&tds.TDS_DONE_COUNT == tds.TDS_DONE_COUNT {
-				result.rowsAffected = int64(typed.Count)
-			}
-			return nil, result, nil
-		default:
-			return nil, nil, fmt.Errorf("unhandled package type %T for language: %v", pkg, pkg)
-		}
-	}
+	return c.genericResults(ctx)
 }


### PR DESCRIPTION
# Description

Moves the code from `Conn.language` and `Stmt.exec` into one common function in `Conn.genericResults`, as both follow the same principles.

To catch DonePackages and its equivalents DoneInProcPackage and DoneProcPackage the types are defined using alias declarations rather than embedding DonePackage.
This means that for all intents and purposes Go won't differentiate between these three package types. As far as I can see these three types are mainly informational and don't affect the flow of TDS itself so it should be fine.

# How was the patch tested?

`make integration-go`.
