### PR TITLE
Handle ReturnStatusPackage in genericResults

### DIFF
--- a/libase/tds/packageReturnStatus.go
+++ b/libase/tds/packageReturnStatus.go
@@ -9,14 +9,13 @@ import "fmt"
 var _ Package = (*ReturnStatusPackage)(nil)
 
 type ReturnStatusPackage struct {
-	returnValue int32
+	ReturnValue int32
 }
 
 func (pkg *ReturnStatusPackage) ReadFrom(ch BytesChannel) error {
 	var err error
 
-	pkg.returnValue, err = ch.Int32()
-	if err != nil {
+	if pkg.ReturnValue, err = ch.Int32(); err != nil {
 		return ErrNotEnoughBytes
 	}
 
@@ -24,13 +23,9 @@ func (pkg *ReturnStatusPackage) ReadFrom(ch BytesChannel) error {
 }
 
 func (pkg ReturnStatusPackage) WriteTo(ch BytesChannel) error {
-	return ch.WriteInt32(pkg.returnValue)
-}
-
-func (pkg ReturnStatusPackage) ReturnValue() int {
-	return int(pkg.returnValue)
+	return ch.WriteInt32(pkg.ReturnValue)
 }
 
 func (pkg ReturnStatusPackage) String() string {
-	return fmt.Sprintf("%T(%d)", pkg, pkg.returnValue)
+	return fmt.Sprintf("%T(%d)", pkg, pkg.ReturnValue)
 }

--- a/purego/genericExec.go
+++ b/purego/genericExec.go
@@ -66,6 +66,11 @@ func (c *Conn) genericResults(ctx context.Context) (driver.Rows, driver.Result, 
 
 				return false, fmt.Errorf("%T does not have status TDS_DONE_COUNT or TDS_DONE_FINAL set: %s",
 					typed, typed)
+			case *tds.ReturnStatusPackage:
+				if typed.ReturnValue != 0 {
+					return false, fmt.Errorf("received return status %d", typed.ReturnValue)
+				}
+				return false, nil
 			default:
 				return false, fmt.Errorf("unhandled package type %T", typed)
 			}


### PR DESCRIPTION
# Description

Handles the `ReturnStatusPackage` in `genericResults`. This package is send e.g. when executing a stored procedure with a return value.

# How was the patch tested?

Manually with `goase 'sp_serveroption SYB_BACKUP, timeout, false'`.