### PR TITLE
Modify EnvChangeHook

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -238,7 +238,7 @@ func (tdsChan *Channel) Logout() error {
 func (tdsChan *Channel) handleSpecialPackage(pkg Package) (bool, error) {
 	if envChange, ok := pkg.(*EnvChangePackage); ok {
 		for _, member := range envChange.members {
-			tdsChan.callEnvChangeHooks(member.Type, member.NewValue, member.OldValue)
+			tdsChan.callEnvChangeHooks(member.Type, member.OldValue, member.NewValue)
 		}
 		return false, nil
 	}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

# Description

Modify arguments in `tdsChan.callEnvChangeHooks` since the arguments were swapped, which led to a confusing output (See e.g. `updateDatabaseName` in [purego-main](https://github.com/SAP/go-ase/blob/master/cmd/goase/main.go#L45)).

# How was the patch tested?

manually
