### PR TITLE
Fix purego erroring if the server doesn't answer fast enough

### DIFF
--- a/libase/term/helpers.go
+++ b/libase/term/helpers.go
@@ -102,11 +102,6 @@ func processRows(rows driver.Rows) error {
 	fmt.Printf("\n")
 
 	cells := make([]driver.Value, len(colNames))
-	cellsI := make([]interface{}, len(colNames))
-
-	for i, cell := range cells {
-		cellsI[i] = &cell
-	}
 
 	for {
 		err := rows.Next(cells)

--- a/purego/conn.go
+++ b/purego/conn.go
@@ -89,8 +89,7 @@ func NewConnWithHooks(ctx context.Context, dsn *libdsn.Info, envChangeHooks []td
 
 	// TODO can this be passed another way?
 	if dsn.Database != "" {
-		_, err = conn.ExecContext(ctx, "use "+dsn.Database, nil)
-		if err != nil {
+		if _, err = conn.ExecContext(ctx, "use "+dsn.Database, nil); err != nil {
 			return nil, fmt.Errorf("go-ase: error switching to database %s: %w", dsn.Database, err)
 		}
 	}

--- a/purego/rows.go
+++ b/purego/rows.go
@@ -108,10 +108,10 @@ func (rows *Rows) NextResultSet() error {
 	}
 }
 
-func (rows *Rows) ColumnTypeLength(index int) (int64, bool) {
+func (rows Rows) ColumnTypeLength(index int) (int64, bool) {
 	return rows.RowFmt.Fmts[index].MaxLength(), true
 }
 
-func (rows *Rows) ColumnTypeDatabaseTypeName(index int) string {
+func (rows Rows) ColumnTypeDatabaseTypeName(index int) string {
 	return string(rows.RowFmt.Fmts[index].DataType())
 }

--- a/purego/rows.go
+++ b/purego/rows.go
@@ -41,8 +41,7 @@ func (rows Rows) Columns() []string {
 
 func (rows *Rows) Close() error {
 	for {
-		err := rows.NextResultSet()
-		if err != nil {
+		if err := rows.NextResultSet(); err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}


### PR DESCRIPTION
# Description

If formats or field for `Param`/`RowFmt` or `Params`/`Rows` are read and the server isn't sending packets fast enough `FieldFmt.ReadFrom` and `FieldData.ReadFrom` may return an `io.EOF` when instead they should return `ErrNotEnoughBytes`.

I've also updated the `Rows` code to utilize `NextPackageUntil` and fixed some style issues I've noticed.

# How was the patch tested?

`make integration-go`.