### PR TITLE
Handle strings and fix lockups in purego

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -144,8 +144,7 @@ func (tdsChan *Channel) Close() error {
 
 	if tdsChan.channelId == 0 {
 		// Channel 0 is the main communication channel - send logout packages
-		err := tdsChan.Logout()
-		if err != nil {
+		if err := tdsChan.Logout(); err != nil {
 			me = multierror.Append(me, fmt.Errorf("error in logout sequence: %w", err))
 		}
 	} else {
@@ -158,8 +157,7 @@ func (tdsChan *Channel) Close() error {
 		teardown.Data = nil
 		tdsChan.CurrentHeaderType = TDS_BUF_CLOSE
 
-		err := tdsChan.sendPacket(teardown)
-		if err != nil {
+		if err := tdsChan.sendPacket(teardown); err != nil {
 			me = multierror.Append(me,
 				fmt.Errorf("error sending teardown for channel %d: %w",
 					tdsChan.channelId, err))

--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -206,7 +206,7 @@ func (tdsChan *Channel) Logout() error {
 		return fmt.Errorf("error sending logout package: %w", err)
 	}
 
-	pkg, err := tdsChan.NextPackage(context.Background(), true)
+	pkg, err := tdsChan.NextPackage(context.Background(), false)
 	if err != nil {
 		return fmt.Errorf("error reading logout response: %w", err)
 	}

--- a/libase/types/bytes.go
+++ b/libase/types/bytes.go
@@ -96,6 +96,11 @@ func (t DataType) Bytes(endian binary.ByteOrder, value interface{}) ([]byte, err
 		return bs, nil
 	}
 
+	switch typed := value.(type) {
+	case string:
+		value = []byte(typed)
+	}
+
 	buf := &bytes.Buffer{}
 	err := binary.Write(buf, endian, value)
 	if err != nil {

--- a/purego/conn.go
+++ b/purego/conn.go
@@ -98,8 +98,7 @@ func NewConnWithHooks(ctx context.Context, dsn *libdsn.Info, envChangeHooks []td
 }
 
 func (c *Conn) Close() error {
-	err := c.Conn.Close()
-	if err != nil {
+	if err := c.Conn.Close(); err != nil {
 		return fmt.Errorf("go-ase: error closing TDS connection: %w", err)
 	}
 

--- a/purego/genericExec.go
+++ b/purego/genericExec.go
@@ -27,8 +27,7 @@ func (c *Conn) GenericExec(ctx context.Context, query string, args []driver.Name
 	}
 
 	for i := range args {
-		err := stmt.CheckNamedValue(&args[i])
-		if err != nil {
+		if err := stmt.CheckNamedValue(&args[i]); err != nil {
 			return nil, nil, fmt.Errorf("go-ase: error checking argument: %w", err)
 		}
 	}


### PR DESCRIPTION
# Description

While working on the examples I noticed that strings aren't handled by `binary.Write`. Instead strings are transformed to `[]byte`.
While doing this I also noticed that `libase/tds.Channel.Logout` hangs if the server ends the communication prematurely.

# How was the patch tested?

`make integration-go` and `make integration-cgo`.