### PR TITLE
Adjust Precision/Scale of Decimal-Types

### DIFF
--- a/libase/tds/field.go
+++ b/libase/tds/field.go
@@ -717,12 +717,12 @@ type fieldDataPrecisionScale struct {
 func (field *fieldDataPrecisionScale) ReadFrom(ch BytesChannel) (int, error) {
 	n, err := field.readFrom(ch)
 	if err != nil {
-		return 0, err
+		return n, err
 	}
 
 	dec, ok := field.value.(*types.Decimal)
 	if !ok {
-		return 0, fmt.Errorf("%T is not of type decimal", field.value)
+		return n, fmt.Errorf("%T is not of type decimal", field.value)
 	}
 
 	switch fieldFmt := field.fmt.(type) {
@@ -733,7 +733,7 @@ func (field *fieldDataPrecisionScale) ReadFrom(ch BytesChannel) (int, error) {
 		dec.Precision = int(fieldFmt.precision)
 		dec.Scale = int(fieldFmt.scale)
 	default:
-		return 0, fmt.Errorf("%T is not of type %T", field.value, fieldFmt)
+		return n, fmt.Errorf("%T is neither of type DecNFieldFmt nor NumNFieldFmt", field.value)
 	}
 
 	return n, nil


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

# Description

The precision and scale of decimal-datatypes was not set yet, wherefore the output of the respective datatypes was not correct. This patch sets the precision and scale to the respective datatypes and fixes this bug. 

# How was the patch tested?

manually, `go-ase-tools`
