### PR TITLE
Add term.Entrypoint and flag `-f` to read SQL commands from a file

### DIFF
--- a/cmd/cgoase/main.go
+++ b/cmd/cgoase/main.go
@@ -6,10 +6,8 @@ package main
 
 import (
 	"database/sql"
-	"flag"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/SAP/go-ase/cgo"
 	"github.com/SAP/go-ase/libase/term"
@@ -37,14 +35,7 @@ func doMain() error {
 	}
 	defer db.Close()
 
-	if len(flag.Args()) > 0 {
-		// Positional arguments were supplied, execute these as SQL
-		// statements
-		query := strings.Join(flag.Args(), " ") + ";"
-		return term.ParseAndExecQueries(db, query)
-	}
-
-	return term.Repl(db)
+	return term.Entrypoint(db)
 }
 
 func handleMessage(msg cgo.Message) {

--- a/cmd/goase/main.go
+++ b/cmd/goase/main.go
@@ -6,10 +6,8 @@ package main
 
 import (
 	"database/sql"
-	"flag"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/SAP/go-ase/libase/tds"
 	"github.com/SAP/go-ase/libase/term"
@@ -37,14 +35,7 @@ func doMain() error {
 	db := sql.OpenDB(connector)
 	defer db.Close()
 
-	if len(flag.Args()) > 0 {
-		// Positional arguments were supplied, execute these as SQL
-		// statements
-		query := strings.Join(flag.Args(), " ") + ";"
-		return term.ParseAndExecQueries(db, query)
-	}
-
-	return term.Repl(db)
+	return term.Entrypoint(db)
 }
 
 func updateDatabaseName(typ tds.EnvChangeType, oldValue, newValue string) {

--- a/libase/term/term.go
+++ b/libase/term/term.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2020 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package term
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"database/sql"
+)
+
+var (
+	fInputFile = flag.String("f", "", "Read SQL commands from file")
+)
+
+func Entrypoint(db *sql.DB) error {
+	flag.Parse()
+
+	if len(flag.Args()) == 0 || *fInputFile == "" {
+		return Repl(db)
+	}
+
+	query := strings.Join(flag.Args(), " ") + ";"
+
+	if *fInputFile != "" {
+		bs, err := ioutil.ReadFile(*fInputFile)
+		if err != nil {
+			return fmt.Errorf("term: error reading file '%s': %w", *fInputFile, err)
+		}
+		query = string(bs)
+	}
+
+	return ParseAndExecQueries(db, query)
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

1. Adds `-f` flag, a file to read SQL commands from
2. Adds `term.Entrypoint` as a common entrypoint for both `cgoase` and `goase`.


**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
