### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,11 +1,4 @@
 ---
-
-<!--
-SPDX-FileCopyrightText: 2020 SAP SE
-
-SPDX-License-Identifier: Apache-2.0
--->
-
 name: Bug report
 about: Create a report to help us improve
 title: ''
@@ -13,6 +6,12 @@ labels: ''
 assignees: ''
 
 ---
+
+<!--
+SPDX-FileCopyrightText: 2020 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
 
 **Description**
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2020 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,11 +1,4 @@
 ---
-
-<!--
-SPDX-FileCopyrightText: 2020 SAP SE
-
-SPDX-License-Identifier: Apache-2.0
--->
-
 name: Feature request
 about: Suggest an idea for this project
 title: ''
@@ -13,6 +6,12 @@ labels: ''
 assignees: ''
 
 ---
+
+<!--
+SPDX-FileCopyrightText: 2020 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
 
 **Problem Description**
 


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

The issue templates were broken due to the SPDX header inside the
markdown header.

**Related issues**

\-

**Tests**

- [ ] make lint
- [ ] make test-go / make test-cgo
- [ ] make integration-go / make integration-cgo
