### PR TITLE
Fix condition for flag.Args and fInputFile

### DIFF
--- a/libase/term/term.go
+++ b/libase/term/term.go
@@ -20,7 +20,7 @@ var (
 func Entrypoint(db *sql.DB) error {
 	flag.Parse()
 
-	if len(flag.Args()) == 0 || *fInputFile == "" {
+	if len(flag.Args()) == 0 && *fInputFile == "" {
 		return Repl(db)
 	}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

In the PR for `-f` I had moved around the code in `term.Entrypoint` without updating the condition, causing the binaries to always run into the interactive shell.

**Related issues**

\-

**Tests**

- [x] make lint
- [ ] make test-go / make test-cgo
- [ ] make integration-go / make integration-cgo
