### PR TITLE
Implement a timeout for logging out

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -200,12 +201,15 @@ func (tdsChan *Channel) Close() error {
 
 // Logout implements the logout sequence.
 func (tdsChan *Channel) Logout() error {
-	err := tdsChan.SendPackage(context.Background(), &LogoutPackage{})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	err := tdsChan.SendPackage(ctx, &LogoutPackage{})
 	if err != nil {
 		return fmt.Errorf("error sending logout package: %w", err)
 	}
 
-	pkg, err := tdsChan.NextPackage(context.Background(), false)
+	pkg, err := tdsChan.NextPackage(ctx, true)
 	if err != nil {
 		return fmt.Errorf("error reading logout response: %w", err)
 	}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Originally waiting on the the ASE to send packages was disabled to prevent a lockup with coredumps etc.pp. - but that can cause errors to be returned when the server doesn't answer immediately to a logout request.

Instead `Channel.Logout` now waits for one minute before throwing an error.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
