### PR TITLE
Fix leftover package in stored procedure queries

### DIFF
--- a/examples/purego/eedexample/main.go
+++ b/examples/purego/eedexample/main.go
@@ -47,7 +47,26 @@ func DoMain() error {
 				fmt.Printf("    %d: %s\n", eed.MsgNumber, eed.Msg)
 			}
 		}
-		return err
+	}
+
+	if _, err := db.Exec("create table eed_example values (int, string)"); err != nil {
+		var eedError *tds.EEDError
+		if errors.As(err, &eedError) {
+			fmt.Println("Messages from ASE server:")
+			for _, eed := range eedError.EEDPackages {
+				fmt.Printf("    %d: %s\n", eed.MsgNumber, eed.Msg)
+			}
+		}
+	}
+
+	if _, err := db.Exec("create database testDatabase"); err != nil {
+		var eedError *tds.EEDError
+		if errors.As(err, &eedError) {
+			fmt.Println("Messages from ASE server:")
+			for _, eed := range eedError.EEDPackages {
+				fmt.Printf("    %d: %s\n", eed.MsgNumber, eed.Msg)
+			}
+		}
 	}
 
 	return nil

--- a/examples/purego/eedexample/main_test.go
+++ b/examples/purego/eedexample/main_test.go
@@ -13,4 +13,9 @@ func ExampleDoMain() {
 	// Output:
 	// Messages from ASE server:
 	//     17231: No login with the specified name exists.
+	// Messages from ASE server:
+	//     156: Incorrect syntax near the keyword 'values'.
+	//
+	// Messages from ASE server:
+	//     1809: CREATE DATABASE must be preceded by a 'USE master' command.  Check with your DBO <or a user with System Administrator (SA) role> if you do not have permission to USE master.
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

If a stored procedure is executed a ReturnStatusPackage is returned. If the return value is not 0 the processing function returns an error - which then leaves the DonePackage in the channel queue.

That can cause issues if more queries are send afterwards, e.g.:
```go
if _, err := db.Exec("sp_adduser login"); err != nil {
   // Receives an error with the return value - error is logged/handled/etc.pp.
}
if _, err := db.Exec("insert into ..."); err != nil {
  // Receives no error, as the DonePackage from the `sp_adduser` query is still in the queue
}
```

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
