### PR TITLE
Fix index/ordinal check

### DIFF
--- a/purego/dynamic.go
+++ b/purego/dynamic.go
@@ -230,8 +230,7 @@ func (stmt Stmt) GenericExec(ctx context.Context, args []driver.NamedValue) (dri
 	if stmt.paramFmt != nil {
 		stmt.pkg.Status |= tds.TDS_DYNAMIC_HASARGS
 	}
-	err := stmt.conn.Channel.QueuePackage(ctx, stmt.pkg)
-	if err != nil {
+	if err := stmt.conn.Channel.QueuePackage(ctx, stmt.pkg); err != nil {
 		return nil, nil, fmt.Errorf("error queueing dynamic statement exec package: %w", err)
 	}
 	stmt.Reset()
@@ -268,8 +267,7 @@ func (stmt Stmt) GenericExec(ctx context.Context, args []driver.NamedValue) (dri
 	}
 
 	// Receive response
-	err = stmt.recvDynAck(ctx)
-	if err != nil {
+	if err := stmt.recvDynAck(ctx); err != nil {
 		return nil, nil, err
 	}
 

--- a/purego/dynamic.go
+++ b/purego/dynamic.go
@@ -263,16 +263,6 @@ func (stmt Stmt) GenericExec(ctx context.Context, args []driver.NamedValue) (dri
 	return stmt.conn.genericResults(ctx)
 }
 
-func (stmt Stmt) CheckNamedValues(namedValues []*driver.NamedValue) error {
-	for _, nv := range namedValues {
-		err := stmt.CheckNamedValue(nv)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (stmt Stmt) CheckNamedValue(named *driver.NamedValue) error {
 	var fieldFmts []tds.FieldFmt
 	if stmt.paramFmt != nil {

--- a/purego/dynamic.go
+++ b/purego/dynamic.go
@@ -112,7 +112,8 @@ func (stmt *Stmt) allocateOnServer(ctx context.Context) error {
 				stmt.rowFmt = typed
 				return false, nil
 			case *tds.DonePackage:
-				if typed.Status != tds.TDS_DONE_FINAL && typed.Status != tds.TDS_DONE_INXACT {
+				if typed.Status != tds.TDS_DONE_FINAL &&
+					typed.Status&tds.TDS_DONE_INXACT != tds.TDS_DONE_INXACT {
 					return false, fmt.Errorf("DonePackage does not have status TDS_DONE_FINAL or TDS_DONE_INXACT set: %s",
 						typed)
 				}

--- a/purego/dynamic.go
+++ b/purego/dynamic.go
@@ -283,13 +283,12 @@ func (stmt Stmt) CheckNamedValue(named *driver.NamedValue) error {
 		return fmt.Errorf("go-ase: both row and paramFmt are unset")
 	}
 
-	index := named.Ordinal - 1
-	if index > len(fieldFmts) {
-		return fmt.Errorf("go-ase: ordinal %d is larger than the number of columns %d",
-			named.Ordinal, len(fieldFmts))
+	if named.Ordinal-1 >= len(fieldFmts) {
+		return fmt.Errorf("go-ase: ordinal %d (index %d) is larger than the number of expected arguments %d",
+			named.Ordinal, named.Ordinal-1, len(fieldFmts))
 	}
 
-	val, err := fieldFmts[index].DataType().ConvertValue(named.Value)
+	val, err := fieldFmts[named.Ordinal-1].DataType().ConvertValue(named.Value)
 	if err != nil {
 		return fmt.Errorf("go-ase: error converting value: %w", err)
 	}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

When passing exactly one too many arguments to the purego implementation the code panics because the conditional checked the index against the length instead of the highest index.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
