### PR TITLE
Null-pad CHAR, VARCHAR and LONGCHAR

### DIFF
--- a/cgo/rows.go
+++ b/cgo/rows.go
@@ -91,7 +91,7 @@ func newRows(cmd *Command) (*Rows, error) {
 
 		// Set padding for datatypes that support it.
 		switch r.dataFmts[i].datatype {
-		case C.CS_BINARY_TYPE, C.CS_LONGBINARY_TYPE, C.CS_VARBINARY_TYPE:
+		case C.CS_BINARY_TYPE, C.CS_LONGBINARY_TYPE, C.CS_VARBINARY_TYPE, C.CS_CHAR_TYPE, C.CS_VARCHAR_TYPE, C.CS_LONGCHAR_TYPE:
 			r.dataFmts[i].format = C.CS_FMT_PADNULL
 		case C.CS_XML_TYPE:
 			r.dataFmts[i].format = C.CS_FMT_NULLTERM


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

The cgo implementation didn't instruct Client-Library to appropriately pad or null-terminate the types CHAR, VARCHAR and LONGCHAR.

**Related issues**

\-

**Tests**

- [ ] make lint
- [ ] make test-go / make test-cgo
- [ ] make integration-go / make integration-cgo
