### PR TITLE
Always send a DonePackage{TDS_DONE_FINAL} as the final package

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -340,7 +340,7 @@ func (tdsChan *Channel) NextPackageUntil(ctx context.Context, wait bool, process
 
 		ok, err := processPkg(pkg)
 		if err != nil {
-			err = fmt.Errorf("error in user-defined processing function: %w", err)
+			err = fmt.Errorf("tds: error in user-defined processing function: %w", err)
 
 			// Only return an EEDError if there were EEDPackages
 			if len(eedError.EEDPackages) == 0 {

--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"sync"
 	"time"
@@ -521,6 +522,26 @@ func (tdsChan *Channel) tryParsePackage() bool {
 	// Attempt to process data from channel into a Package.
 	tokenByte, err := tdsChan.queueRx.Byte()
 	if err != nil {
+		if errors.Is(err, io.EOF) {
+			// If the error is io.EOF then the payload from the server
+			// has been fully consumed.
+			// TDS doesn't always send a DonePackage with TDS_DONE_FINAL
+			// - usually only when a procedure with multiple commands is
+			// being executed.
+			lastPkg, ok := tdsChan.lastPkgRx.(*DonePackage)
+			if !ok {
+				return false
+			}
+
+			if lastPkg.Status == TDS_DONE_FINAL ||
+				lastPkg.Status == TDS_DONE_COUNT {
+				// The last received package is a DonePackage with
+				// TDS_DONE_FINAL or TDS_DONE_COUNT - no need to add one.
+				return false
+			}
+
+			tdsChan.packageCh <- &DonePackage{Status: TDS_DONE_FINAL}
+		}
 		return false
 	}
 

--- a/libase/term/helpers.go
+++ b/libase/term/helpers.go
@@ -53,15 +53,13 @@ func rawProcess(driverConn interface{}, query string) error {
 	if rows != nil && !reflect.ValueOf(rows).IsNil() {
 		defer rows.Close()
 
-		err = processRows(rows)
-		if err != nil {
+		if err := processRows(rows); err != nil {
 			return fmt.Errorf("error processing rows: %w", err)
 		}
 	}
 
 	if result != nil && !reflect.ValueOf(result).IsNil() {
-		err = processResult(result)
-		if err != nil {
+		if err := processResult(result); err != nil {
 			return fmt.Errorf("error processing result: %w", err)
 		}
 	}
@@ -104,8 +102,7 @@ func processRows(rows driver.Rows) error {
 	cells := make([]driver.Value, len(colNames))
 
 	for {
-		err := rows.Next(cells)
-		if err != nil {
+		if err := rows.Next(cells); err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}

--- a/purego/conn.go
+++ b/purego/conn.go
@@ -77,8 +77,7 @@ func NewConnWithHooks(ctx context.Context, dsn *libdsn.Info, envChangeHooks []td
 
 	loginConfig.AppName = dsn.PropDefault("appname", "github.com/SAP/go-ase/purego")
 
-	err = conn.Channel.Login(ctx, loginConfig)
-	if err != nil {
+	if err := conn.Channel.Login(ctx, loginConfig); err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("go-ase: error logging in: %w", err)
 	}

--- a/purego/genericExec.go
+++ b/purego/genericExec.go
@@ -64,7 +64,9 @@ func (c *Conn) GenericExec(ctx context.Context, query string, args []driver.Name
 func (c *Conn) genericResults(ctx context.Context) (driver.Rows, driver.Result, error) {
 	rows := &Rows{Conn: c}
 	result := &Result{}
+
 	returnStatus := -1
+	recvErr := false
 
 	_, err := c.Channel.NextPackageUntil(ctx, true,
 		func(pkg tds.Package) (bool, error) {
@@ -85,25 +87,35 @@ func (c *Conn) genericResults(ctx context.Context) (driver.Rows, driver.Result, 
 				}
 
 				if typed.Status&tds.TDS_DONE_ERROR == tds.TDS_DONE_ERROR {
-					return true, fmt.Errorf("received done package with error: %s", typed)
+					recvErr = true
+					return false, nil
 				}
 
-				if typed.Status&tds.TDS_DONE_PROC == tds.TDS_DONE_PROC ||
-					typed.Status&tds.TDS_DONE_INXACT == tds.TDS_DONE_INXACT ||
-					typed.Status == tds.TDS_DONE_FINAL {
+				if typed.Status&tds.TDS_DONE_INXACT == tds.TDS_DONE_INXACT {
+					return false, nil
+				}
+
+				if typed.Status&tds.TDS_DONE_PROC == tds.TDS_DONE_PROC {
+					return false, nil
+				}
+
+				if typed.Status == tds.TDS_DONE_FINAL {
 					if returnStatus > 0 {
-						return true, fmt.Errorf("query failed with return status %d", returnStatus)
+						return true, fmt.Errorf("go-ase: query failed with return status %d", returnStatus)
+					}
+					if recvErr {
+						return true, fmt.Errorf("go-ase: query failed with errors")
 					}
 					return true, nil
 				}
 
-				return false, fmt.Errorf("%T is not recognized by go-ase: %s",
+				return false, fmt.Errorf("go-ase: %T is not recognized by go-ase: %s",
 					typed, typed)
 			case *tds.ReturnStatusPackage:
 				returnStatus = int(typed.ReturnValue)
 				return false, nil
 			default:
-				return false, fmt.Errorf("unhandled package type %T", typed)
+				return false, fmt.Errorf("go-ase: unhandled package type %T", typed)
 			}
 		},
 	)

--- a/tests/cgotest/main_test.go
+++ b/tests/cgotest/main_test.go
@@ -17,8 +17,7 @@ import (
 func TestMain(m *testing.M) {
 	err := testMain(m)
 	if err != nil {
-		log.Fatalf("%v", err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }
 
@@ -32,8 +31,7 @@ func testMain(m *testing.M) error {
 	}
 	defer simpleTeardown()
 
-	err = libtest.RegisterDSN("username password", simpleDSN, cgo.NewConnector)
-	if err != nil {
+	if err := libtest.RegisterDSN("username password", simpleDSN, cgo.NewConnector); err != nil {
 		return fmt.Errorf("error setting up simple database: %w", err)
 	}
 
@@ -43,13 +41,11 @@ func testMain(m *testing.M) error {
 	}
 	defer userstoreTeardown()
 
-	err = libtest.RegisterDSN("userstorekey", userstoreDSN, cgo.NewConnector)
-	if err != nil {
+	if err := libtest.RegisterDSN("userstorekey", userstoreDSN, cgo.NewConnector); err != nil {
 		return fmt.Errorf("error setting up userstore database: %w", err)
 	}
 
-	rc := m.Run()
-	if rc != 0 {
+	if rc := m.Run(); rc != 0 {
 		return fmt.Errorf("tests failed with %d", rc)
 	}
 

--- a/tests/puregotest/main_test.go
+++ b/tests/puregotest/main_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	err := testMain(m)
-	if err != nil {
-		log.Fatalf("%v", err)
+	if err := testMain(m); err != nil {
+		log.Fatal(err)
 	}
 }
 
@@ -27,13 +26,11 @@ func testMain(m *testing.M) error {
 	}
 	defer simpleTeardown()
 
-	err = libtest.RegisterDSN("username password", simpleDSN, ase.NewConnector)
-	if err != nil {
+	if err := libtest.RegisterDSN("username password", simpleDSN, ase.NewConnector); err != nil {
 		return fmt.Errorf("error setting up simple database: %w", err)
 	}
 
-	rc := m.Run()
-	if rc != 0 {
+	if rc := m.Run(); rc != 0 {
 		return fmt.Errorf("tests failed with %d", rc)
 	}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

TDS doesn't always send a `DonePackage{Status: TDS_DONE_FINAL}` as the final package in a query - which causes problems with procedures that execute other procedures and the way we consume packages.

E.g. the statement `create proc proc1 from select "ping"; proc1` will send `DonePackage{Status: TDS_DONE_INXACT}` as the last package.
This package also occurs in the statement 
```sql
create proc proc2 from
begin
  proc1
  proc1
end
proc1
```
But not at the last statement - here the `DonePackage{TDS_DONE_INXACT}` will occur twice for the two `proc1` calls and the final package is a `DonePackage{TDS_DONE_FINAL}`.

This PR changes the `tryParsePackage` method so that the last package will always be a `DonePackage{TDS_DONE_FINAL}` or `DonePackage{TDS_DONE_COUNT}`.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
