### PR TITLE
Fix go transaction examples for databases with 'ddl in tran'

### DIFF
--- a/examples/purego/subtransaction/main_test.go
+++ b/examples/purego/subtransaction/main_test.go
@@ -13,8 +13,8 @@ func ExampleDoMain() {
 		log.Fatal(err)
 	}
 	// Output:
-	// opening transaction
 	// creating table simple
+	// opening transaction
 	// inserting values into simple
 	// reading table contents
 	// a: 2147483647
@@ -27,7 +27,5 @@ func ExampleDoMain() {
 	// b: another string
 	// rolling back subtransaction
 	// reading table contents after subtransaction rollback
-	// a: 2147483647
-	// b: a string
 	// committing transaction
 }

--- a/examples/purego/transaction/main_test.go
+++ b/examples/purego/transaction/main_test.go
@@ -13,8 +13,8 @@ func ExampleDoMain() {
 		log.Fatal(err)
 	}
 	// Output:
-	// opening transaction
 	// creating table simple
+	// opening transaction
 	// inserting values into simple
 	// preparing statement
 	// executing prepared statement


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Some databases do not have the `ddl in tran` database option set, which would cause these examples to fail as no tables can be created.
Since the examples should be option-agnostic the statements to create the relevant table are moved above the transaction opening.

I've also fixed some style issues while I was at it.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
