### PR TITLE
Consume all packages until DonePackage{Status: TDS_DONE_FINAL} if an error occcurs

### DIFF
--- a/purego/helper.go
+++ b/purego/helper.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2020 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package purego
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/SAP/go-ase/libase/tds"
+)
+
+func handleDonePackage(pkg *tds.DonePackage) (bool, error) {
+	if pkg.Status == tds.TDS_DONE_COUNT {
+		return true, io.EOF
+	}
+
+	if pkg.Status&tds.TDS_DONE_ERROR == tds.TDS_DONE_ERROR {
+		return true, fmt.Errorf("query failed with errors")
+	}
+
+	if pkg.Status&tds.TDS_DONE_MORE == tds.TDS_DONE_MORE ||
+		pkg.Status&tds.TDS_DONE_INXACT == tds.TDS_DONE_INXACT ||
+		pkg.Status&tds.TDS_DONE_PROC == tds.TDS_DONE_PROC {
+		return false, nil
+	}
+
+	if pkg.Status == tds.TDS_DONE_FINAL {
+		return true, io.EOF
+	}
+
+	return false, fmt.Errorf("%T with unrecognized Status: %s", pkg, pkg)
+}

--- a/purego/rows.go
+++ b/purego/rows.go
@@ -53,9 +53,6 @@ func (rows *Rows) Close() error {
 }
 
 func (rows *Rows) Next(dst []driver.Value) error {
-	returnStatus := -1
-	recvErr := false
-
 	_, err := rows.Conn.Channel.NextPackageUntil(context.Background(), true,
 		func(pkg tds.Package) (bool, error) {
 			switch typed := pkg.(type) {
@@ -76,35 +73,25 @@ func (rows *Rows) Next(dst []driver.Value) error {
 					return true, io.EOF
 				}
 
-				if typed.Status&tds.TDS_DONE_MORE == tds.TDS_DONE_MORE {
-					return false, nil
-				}
-
 				if typed.Status&tds.TDS_DONE_ERROR == tds.TDS_DONE_ERROR {
-					recvErr = true
-					return false, nil
+					return true, fmt.Errorf("go-ase: query failed with errors")
 				}
 
-				if typed.Status&tds.TDS_DONE_INXACT == tds.TDS_DONE_INXACT {
-					return false, nil
-				}
-
-				if typed.Status&tds.TDS_DONE_PROC == tds.TDS_DONE_PROC {
+				if typed.Status&tds.TDS_DONE_MORE == tds.TDS_DONE_MORE ||
+					typed.Status&tds.TDS_DONE_INXACT == tds.TDS_DONE_INXACT ||
+					typed.Status&tds.TDS_DONE_PROC == tds.TDS_DONE_PROC {
 					return false, nil
 				}
 
 				if typed.Status == tds.TDS_DONE_FINAL {
-					if returnStatus > 0 {
-						return true, fmt.Errorf("go-ase: query failed with return status %d", returnStatus)
-					}
-					if recvErr {
-						return true, fmt.Errorf("go-ase: query failed with errors")
-					}
 					return true, io.EOF
 				}
-				return false, nil
+
+				return false, fmt.Errorf("go-ase: %T with unrecognized Status: %s", typed, typed)
 			case *tds.ReturnStatusPackage:
-				returnStatus = int(typed.ReturnValue)
+				if typed.ReturnValue != 0 {
+					return true, fmt.Errorf("go-ase: query failed with return status %d", typed.ReturnValue)
+				}
 				return false, nil
 			default:
 				return true, fmt.Errorf("unhandled package type %T: %v", pkg, pkg)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Callers of `Channel.NextPackageUntil` had to include workarounds to consume all packages for their data stream.
As a previous PR now ensures that a `DonePackage{TDS_DONE_FINAL}` finishes any given data stream the function itself can now guarantee that all packages are consumed if an error occurs.
This made it possible to clean up and reuse the code.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
