### PR TITLE
Make eedexample agnostic from environment

### DIFF
--- a/examples/purego/eedexample/main.go
+++ b/examples/purego/eedexample/main.go
@@ -39,6 +39,7 @@ func DoMain() error {
 		}
 	}()
 
+	fmt.Println("sp_adduser")
 	if _, err := db.Exec("sp_adduser nologin"); err != nil {
 		var eedError *tds.EEDError
 		if errors.As(err, &eedError) {
@@ -49,6 +50,7 @@ func DoMain() error {
 		}
 	}
 
+	fmt.Println("create table")
 	if _, err := db.Exec("create table eed_example values (int, string)"); err != nil {
 		var eedError *tds.EEDError
 		if errors.As(err, &eedError) {
@@ -59,7 +61,8 @@ func DoMain() error {
 		}
 	}
 
-	if _, err := db.Exec("create database testDatabase"); err != nil {
+	fmt.Println("create database")
+	if _, err := db.Exec("create database"); err != nil {
 		var eedError *tds.EEDError
 		if errors.As(err, &eedError) {
 			fmt.Println("Messages from ASE server:")

--- a/examples/purego/eedexample/main_test.go
+++ b/examples/purego/eedexample/main_test.go
@@ -13,11 +13,14 @@ func ExampleDoMain() {
 		log.Printf("Failed to execute example: %v", err)
 	}
 	// Output:
+	// sp_adduser
 	// Messages from ASE server:
 	//     17231: No login with the specified name exists.
+	// create table
 	// Messages from ASE server:
 	//     156: Incorrect syntax near the keyword 'values'.
 	//
+	// create database
 	// Messages from ASE server:
-	//     1809: CREATE DATABASE must be preceded by a 'USE master' command.  Check with your DBO <or a user with System Administrator (SA) role> if you do not have permission to USE master.
+	//     102: Incorrect syntax near 'database'.
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Similar to #134 - this example was dependent on the environment as it relied on the user not logging into the `master` db.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
