### PR TITLE
Support option client-hostname and ensure hostname isn't longer than …

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,15 @@ increasing the queue size.
 
 Defaults to 100.
 
+##### client-hostname
+
+Recognized values: string
+
+The client-hostname to report to the TDS server. Due to protocol
+limitations this will be cut off after 30 characters.
+
+Defaults to the hostname of the machine, acquired using `os.Hostname`.
+
 ##### tls
 
 Recognized values: string

--- a/libase/libdsn/dsn.go
+++ b/libase/libdsn/dsn.go
@@ -27,6 +27,8 @@ type Info struct {
 	Userstorekey string `json:"userstorekey" multiref:"key" validate:"required"`
 	Database     string `json:"database" multiref:"db"`
 
+	ClientHostname string `json:"client-hostname"`
+
 	TLSHostname       string `json:"tls-hostname" multiref:"tls,ssl"`
 	TLSSkipValidation bool   `json:"tls-skip-validation"`
 	TLSCAFile         string `json:"tls-ca"`

--- a/libase/tds/loginConfig.go
+++ b/libase/tds/loginConfig.go
@@ -41,11 +41,19 @@ func NewLoginConfig(dsn *libdsn.Info) (*LoginConfig, error) {
 
 	conf.DSN = dsn
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve hostname: %w", err)
+	if dsn.ClientHostname != "" {
+		conf.Hostname = dsn.ClientHostname
+	} else {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve hostname: %w", err)
+		}
+		conf.Hostname = hostname
 	}
-	conf.Hostname = hostname
+	if len(conf.Hostname) > 30 {
+		conf.Hostname = conf.Hostname[:30]
+	}
+
 	conf.HostProc = strconv.Itoa(os.Getpid())
 
 	conf.ServName = conf.DSN.Host


### PR DESCRIPTION
…30 bytes

<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Currently `tds` will fail to log in if the hostname is longer than 30 bytes and the user has no way to override the hostname, as `os.Hostname` doesn't honour `HOSTNAME`.

Hostnames are now cut off after 30 characters to ensure logging in is possible.
Users can override the hostname by either passing `client-hostname` in the DSN or setting `ASE_CLIENT_HOSTNAME`, allowing for e.g. clusters to use the same hostname.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
