### PR TITLE
Add deBitmaskString

### DIFF
--- a/libase/tds/helper.go
+++ b/libase/tds/helper.go
@@ -43,3 +43,20 @@ func deBitmask(bitmask int, maxValue int) []int {
 
 	return ret
 }
+
+func deBitmaskString(bitmask, maxValue int, toString func(i int) string, defaultValue string) string {
+	values := deBitmask(bitmask, maxValue)
+	if len(values) == 0 {
+		return defaultValue
+	}
+
+	ret := ""
+	for i, value := range values {
+		ret += toString(value)
+		if i+1 != len(values) {
+			ret += "|"
+		}
+	}
+
+	return ret
+}

--- a/libase/tds/helper_test.go
+++ b/libase/tds/helper_test.go
@@ -31,6 +31,25 @@ func TestDeBitmask(t *testing.T) {
 				0x40,
 			},
 		},
+		"maxima binary": {
+			bitmask:  0b10010110,
+			maxValue: 128,
+			expected: []int{
+				0b00000010,
+				0b00000100,
+				0b00010000,
+				0b10000000,
+			},
+		},
+		"maxima hex": {
+			bitmask:  0xc1,
+			maxValue: 0x80,
+			expected: []int{
+				0x1,
+				0x40,
+				0x80,
+			},
+		},
 	}
 
 	for title, cas := range cases {
@@ -41,6 +60,103 @@ func TestDeBitmask(t *testing.T) {
 					t.Errorf("Received unexpected response:")
 					t.Errorf("Expected: %#v", cas.expected)
 					t.Errorf("Received: %#v", recv)
+				}
+			},
+		)
+	}
+}
+
+type deBitmaskTypeUint uint
+
+const (
+	deBitmaskTypeUint1 deBitmaskTypeUint = 0x1
+	deBitmaskTypeUint2 deBitmaskTypeUint = 0x2
+	deBitmaskTypeUint3 deBitmaskTypeUint = 0x4
+	deBitmaskTypeUint4 deBitmaskTypeUint = 0x8
+)
+
+func (t deBitmaskTypeUint) String() string {
+	switch t {
+	case deBitmaskTypeUint1:
+		return "deBitmaskTypeUint1"
+	case deBitmaskTypeUint2:
+		return "deBitmaskTypeUint2"
+	case deBitmaskTypeUint3:
+		return "deBitmaskTypeUint3"
+	case deBitmaskTypeUint4:
+		return "deBitmaskTypeUint4"
+	default:
+		return ""
+	}
+}
+
+type deBitmaskTypeInt int
+
+const (
+	deBitmaskTypeInt1 deBitmaskTypeInt = 0x1
+	deBitmaskTypeInt2 deBitmaskTypeInt = 0x2
+	deBitmaskTypeInt3 deBitmaskTypeInt = 0x8
+	deBitmaskTypeInt4 deBitmaskTypeInt = 0x10
+)
+
+func (t deBitmaskTypeInt) String() string {
+	switch t {
+	case deBitmaskTypeInt1:
+		return "deBitmaskTypeInt1"
+	case deBitmaskTypeInt2:
+		return "deBitmaskTypeInt2"
+	case deBitmaskTypeInt3:
+		return "deBitmaskTypeInt3"
+	case deBitmaskTypeInt4:
+		return "deBitmaskTypeInt4"
+	default:
+		return ""
+	}
+}
+
+func TestDeBitmaskString(t *testing.T) {
+	cases := map[string]struct {
+		bitmask, maxValue int
+		defaultValue      string
+		stringerFn        func(int) string
+		expect            string
+	}{
+		"uint": {
+			bitmask:    int(deBitmaskTypeUint1 | deBitmaskTypeUint3),
+			maxValue:   int(deBitmaskTypeUint4),
+			stringerFn: func(i int) string { return deBitmaskTypeUint(i).String() },
+			expect:     "deBitmaskTypeUint1|deBitmaskTypeUint3",
+		},
+		"uint default": {
+			bitmask:      0,
+			maxValue:     int(deBitmaskTypeUint4),
+			defaultValue: "unused",
+			stringerFn:   func(i int) string { return deBitmaskTypeUint(i).String() },
+			expect:       "unused",
+		},
+		"int": {
+			bitmask:    int(deBitmaskTypeInt2 | deBitmaskTypeInt4),
+			maxValue:   int(deBitmaskTypeInt4),
+			stringerFn: func(i int) string { return deBitmaskTypeInt(i).String() },
+			expect:     "deBitmaskTypeInt2|deBitmaskTypeInt4",
+		},
+		"int default": {
+			bitmask:      0,
+			maxValue:     int(deBitmaskTypeInt4),
+			defaultValue: "default",
+			stringerFn:   func(i int) string { return deBitmaskTypeInt(i).String() },
+			expect:       "default",
+		},
+	}
+
+	for title, cas := range cases {
+		t.Run(title,
+			func(t *testing.T) {
+				result := deBitmaskString(cas.bitmask, cas.maxValue, cas.stringerFn, cas.defaultValue)
+				if result != cas.expect {
+					t.Errorf("Received unexpected result:")
+					t.Errorf("Expected: %s", cas.expect)
+					t.Errorf("Received: %s", result)
 				}
 			},
 		)

--- a/libase/tds/packageDone.go
+++ b/libase/tds/packageDone.go
@@ -84,31 +84,15 @@ func (pkg DonePackage) WriteTo(ch BytesChannel) error {
 }
 
 func (pkg DonePackage) String() string {
-	stati := deBitmask(int(pkg.Status), int(TDS_DONE_CUMULATIVE))
-	strStati := ""
-	if len(stati) == 0 {
-		strStati = TDS_DONE_FINAL.String()
-	} else {
-		for i, status := range stati {
-			strStati += DoneState(status).String()
-			if i+1 != len(stati) {
-				strStati += "|"
-			}
-		}
-	}
+	strStati := deBitmaskString(int(pkg.Status), int(TDS_DONE_CUMULATIVE),
+		func(i int) string { return DoneState(i).String() },
+		TDS_DONE_FINAL.String(),
+	)
 
-	transi := deBitmask(int(pkg.TranState), int(TDS_TRAN_STMT_FAIL))
-	strTransi := ""
-	if len(transi) == 0 {
-		strTransi = TDS_NOT_IN_TRAN.String()
-	} else {
-		for i, trans := range transi {
-			strTransi += TransState(trans).String()
-			if i+1 != len(transi) {
-				strTransi += "|"
-			}
-		}
-	}
+	strTransi := deBitmaskString(int(pkg.TranState), int(TDS_TRAN_STMT_FAIL),
+		func(i int) string { return TransState(i).String() },
+		TDS_NOT_IN_TRAN.String(),
+	)
 
 	return fmt.Sprintf("%T(%s, %s)", pkg, strStati, strTransi)
 }

--- a/libase/tds/packageDynamic.go
+++ b/libase/tds/packageDynamic.go
@@ -198,31 +198,15 @@ func (pkg *DynamicPackage) WriteTo(ch BytesChannel) error {
 }
 
 func (pkg DynamicPackage) String() string {
-	types := deBitmask(int(pkg.Type), int(TDS_DYN_DESCOUT))
-	strTypes := ""
-	if len(types) == 0 {
-		strTypes = TDS_DYN_PREPARE.String()
-	} else {
-		for i, typ := range types {
-			strTypes += DynamicOperationType(typ).String()
-			if i+1 != len(types) {
-				strTypes += "|"
-			}
-		}
-	}
+	strTypes := deBitmaskString(int(pkg.Type), int(TDS_DYN_DESCOUT),
+		func(i int) string { return DynamicOperationType(i).String() },
+		TDS_DYN_PREPARE.String(),
+	)
 
-	stati := deBitmask(int(pkg.Status), int(TDS_DYNAMIC_SUPPRESS_FMT))
-	strStati := ""
-	if len(stati) == 0 {
-		strStati = TDS_DYNAMIC_UNUSED.String()
-	} else {
-		for i, status := range stati {
-			strStati += DynamicStatusType(status).String()
-			if i+1 != len(stati) {
-				strStati += "|"
-			}
-		}
-	}
+	strStati := deBitmaskString(int(pkg.Status), int(TDS_DYNAMIC_SUPPRESS_FMT),
+		func(i int) string { return DynamicStatusType(i).String() },
+		TDS_DYNAMIC_UNUSED.String(),
+	)
 
 	return fmt.Sprintf("%T(%s, %s - %s: %s)", pkg, strTypes, strStati, pkg.ID, pkg.Stmt)
 }

--- a/libase/tds/packet.go
+++ b/libase/tds/packet.go
@@ -74,15 +74,19 @@ func (packet Packet) WriteTo(writer io.Writer) (int64, error) {
 }
 
 func (packet Packet) String() string {
+	strHeaderStatus := deBitmaskString(int(packet.Header.Status), int(TDS_BUFSTAT_SYMENCRYPT),
+		func(i int) string { return PacketHeaderStatus(i).String() },
+		"no status",
+	)
+
 	return fmt.Sprintf(
-		"Type: %s, Status: %s, Length: %d, Channel: %d, PacketNr: %d, Window: %d, DataLen: %d, Data: %#v",
+		"Type: %s, Status: %s, Length: %d, Channel: %d, PacketNr: %d, Window: %d, DataLen: %d",
 		packet.Header.MsgType,
-		packet.Header.Status,
+		strHeaderStatus,
 		packet.Header.Length,
 		packet.Header.Channel,
 		packet.Header.PacketNr,
 		packet.Header.Window,
 		len(packet.Data),
-		packet.Data,
 	)
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Adds `deBitmaskString` to reduce code clutter.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
