### PR TITLE
Trim newlines from EED messages

### DIFF
--- a/examples/purego/eedexample/main_test.go
+++ b/examples/purego/eedexample/main_test.go
@@ -17,7 +17,6 @@ func ExampleDoMain() {
 	//     17231: No login with the specified name exists.
 	// Messages from ASE server:
 	//     156: Incorrect syntax near the keyword 'values'.
-	//
 	// Messages from ASE server:
 	//     1809: CREATE DATABASE must be preceded by a 'USE master' command.  Check with your DBO <or a user with System Administrator (SA) role> if you do not have permission to USE master.
 }

--- a/examples/purego/recorder/main.go
+++ b/examples/purego/recorder/main.go
@@ -51,7 +51,7 @@ func (rec *Recorder) LogMessages() {
 	defer rec.RUnlock()
 
 	for _, eed := range rec.eeds {
-		fmt.Printf("%s: MsgNumber %d: %s", rec.logprefix, eed.MsgNumber, eed.Msg)
+		fmt.Printf("%s: MsgNumber %d: %s\n", rec.logprefix, eed.MsgNumber, eed.Msg)
 	}
 }
 

--- a/libase/tds/packageEED.go
+++ b/libase/tds/packageEED.go
@@ -4,7 +4,10 @@
 
 package tds
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 //go:generate stringer -type=EEDStatus
 type EEDStatus uint8
@@ -83,10 +86,12 @@ func (pkg *EEDPackage) ReadFrom(ch BytesChannel) error {
 	}
 	n += 2
 
-	pkg.Msg, err = ch.String(int(msgLength))
+	msg, err := ch.String(int(msgLength))
 	if err != nil {
 		return ErrNotEnoughBytes
 	}
+	// Some messages contain a trailing newline, but not all.
+	pkg.Msg = strings.TrimSuffix(msg, "\n")
 	n += int(msgLength)
 
 	serverLength, err := ch.Uint8()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Some EED messages contain trailing newlines - but not all. This change makes sure that none have trailing newlines.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
