### PR TITLE
Fix examples

### DIFF
--- a/examples/purego/recorder/main_test.go
+++ b/examples/purego/recorder/main_test.go
@@ -27,9 +27,6 @@ func ExampleDoMain() {
 	// connector: MsgNumber 5704: Changed client character set setting to 'utf8'.
 	// connector: MsgNumber 5701: Changed database context to 'saptools'.
 	// connector: MsgNumber 5703: Changed language setting to 'us_english'.
-	// connector: MsgNumber 5704: Changed client character set setting to 'utf8'.
-	// connector: MsgNumber 5701: Changed database context to 'saptools'.
-	// connector: MsgNumber 5703: Changed language setting to 'us_english'.
 	// connector: MsgNumber 2528: DBCC execution completed. If DBCC printed error messages, contact a user with System Administrator (SA) role.
 	// Opening second database
 	// Received messages on driver recorder:
@@ -41,9 +38,6 @@ func ExampleDoMain() {
 	// driver: MsgNumber 5703: Changed language setting to 'us_english'.
 	// Received messages on connector recorder:
 	// Received messages on connector recorder 2:
-	// connector: MsgNumber 5704: Changed client character set setting to 'utf8'.
-	// connector: MsgNumber 5701: Changed database context to 'saptools'.
-	// connector: MsgNumber 5703: Changed language setting to 'us_english'.
 	// connector: MsgNumber 5704: Changed client character set setting to 'utf8'.
 	// connector: MsgNumber 5701: Changed database context to 'saptools'.
 	// connector: MsgNumber 5703: Changed language setting to 'us_english'.

--- a/examples/purego/simple2/main.go
+++ b/examples/purego/simple2/main.go
@@ -17,7 +17,7 @@ import (
 
 func main() {
 	if err := DoMain(); err != nil {
-		log.Fatalf("godb failed: %v", err)
+		log.Fatalf("simple2 failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Fixes the name used in `simple2` and the expected output in `recorder`.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
