### PR TITLE
Better package parsing

### DIFF
--- a/libase/tds/eedError.go
+++ b/libase/tds/eedError.go
@@ -4,7 +4,10 @@
 
 package tds
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type EEDError struct {
 	EEDPackages  []*EEDPackage
@@ -13,6 +16,13 @@ type EEDError struct {
 
 func (err *EEDError) Add(eed *EEDPackage) {
 	err.EEDPackages = append(err.EEDPackages, eed)
+}
+
+func (err EEDError) Is(other error) bool {
+	if err.WrappedError == nil {
+		return false
+	}
+	return errors.Is(err.WrappedError, other)
 }
 
 func (err EEDError) Error() string {

--- a/libase/tds/packetQueue_test.go
+++ b/libase/tds/packetQueue_test.go
@@ -219,3 +219,40 @@ func TestPacketQueue_WriteBytes(t *testing.T) {
 		)
 	}
 }
+
+func TestPacketQueue_AllPacketsConsumed(t *testing.T) {
+	cases := map[string]struct {
+		queue  *PacketQueue
+		expect bool
+	}{
+		"empty queue returns true": {
+			queue:  prepQueue(0, 0),
+			expect: true,
+		},
+		"finished queue returns true": {
+			queue:  prepQueue(0, 35, &Packet{Data: make([]byte, 35)}),
+			expect: true,
+		},
+		"unfinished queue return false": {
+			queue:  prepQueue(0, 15, &Packet{Data: make([]byte, 35)}),
+			expect: false,
+		},
+		"indices overshooting returns true": {
+			queue:  prepQueue(1, 0, &Packet{Data: make([]byte, 35)}),
+			expect: true,
+		},
+		"one unread byte returns true": {
+			queue:  prepQueue(0, 0, &Packet{Data: []byte{0x1}}),
+			expect: false,
+		},
+	}
+
+	for title, cas := range cases {
+		t.Run(title, func(t *testing.T) {
+			recv := cas.queue.AllPacketsConsumed()
+			if recv != cas.expect {
+				t.Errorf("Expected .AllPacketsConsumed to return %t, got %t", cas.expect, recv)
+			}
+		})
+	}
+}

--- a/purego/dynamicRecv.go
+++ b/purego/dynamicRecv.go
@@ -6,7 +6,9 @@ package purego
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/SAP/go-ase/libase/tds"
 )
@@ -27,7 +29,11 @@ func (stmt Stmt) recvDynAck(ctx context.Context) error {
 		},
 	)
 
-	return err
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
 }
 
 func (stmt Stmt) recvDoneFinal(ctx context.Context) error {
@@ -42,9 +48,13 @@ func (stmt Stmt) recvDoneFinal(ctx context.Context) error {
 				return false, fmt.Errorf("DonePackage does not have status TDS_DONE_FINAL set: %s", done)
 			}
 
-			return true, nil
+			return true, io.EOF
 		},
 	)
 
-	return err
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	return nil
 }

--- a/purego/genericExec.go
+++ b/purego/genericExec.go
@@ -38,7 +38,7 @@ func (c *Conn) DirectExec(ctx context.Context, query string, args ...interface{}
 func (c *Conn) GenericExec(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, driver.Result, error) {
 	if len(args) == 0 {
 		rows, result, err := c.language(ctx, query)
-		if err != nil {
+		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, fmt.Errorf("go-ase: error executing statement: %w", err)
 		}
 		return rows, result, nil


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Fixes parsing of packets by recognizing EOM packets and only resetting after the last failed package parsing attempt.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
