### PR TITLE
Close rows in .Ping

### DIFF
--- a/purego/conn.go
+++ b/purego/conn.go
@@ -121,11 +121,14 @@ func (c *Conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 }
 
 func (c Conn) Ping(ctx context.Context) error {
-	// TODO check rows
 	// TODO implement ErrBadConn check
-	_, _, err := c.language(ctx, "select 'ping'")
+	rows, _, err := c.language(ctx, "select 'ping'")
 	if err != nil {
 		return fmt.Errorf("go-ase: error pinging database: %w", err)
+	}
+
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("go-ase: error closing rows from ping: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

A `select "ping"` returns rows which weren't being closed.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
