### PR TITLE
Add comment as to why io.EOF is returned explicitly

### DIFF
--- a/purego/rows.go
+++ b/purego/rows.go
@@ -87,6 +87,8 @@ func (rows *Rows) Next(dst []driver.Value) error {
 	)
 
 	if err != nil {
+		// database/sql expects only an io.EOF - it doesn't check with
+		// errors.Is.
 		if errors.Is(err, io.EOF) {
 			return io.EOF
 		}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Tripped over this because I didn't add a comment.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
