### PR TITLE
Read PDUs over multiple responses

### DIFF
--- a/libase/tds/conn.go
+++ b/libase/tds/conn.go
@@ -220,10 +220,7 @@ func (tds *Conn) ReadFrom() {
 		default:
 			packet := &Packet{}
 			_, err := packet.ReadFrom(tds.conn)
-			if err != nil {
-				if errors.Is(err, io.EOF) {
-					return
-				}
+			if err != nil && !errors.Is(err, io.EOF) {
 				tds.errCh <- fmt.Errorf("error reading packet: %w", err)
 				continue
 			}
@@ -238,6 +235,11 @@ func (tds *Conn) ReadFrom() {
 
 			// Errors are recorded in the channels' error channel.
 			tdsChan.WritePacket(packet)
+
+			// err from packet.ReadFrom
+			if errors.Is(err, io.EOF) {
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

PDUs could stretch over multiple responses in the cloud variant of ASE. This change accounts for these occurrences.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
