### PR TITLE
Require user to explicitly allow TLS instead of enabling implicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,12 +327,20 @@ Defaults to the hostname of the machine, acquired using `os.Hostname`.
 
 ##### tls
 
+Recognized values: bool
+
+Activates TLS for the connection. Any other TLS option is ignored unless tls is set to true.
+
+Defaults to true if the target port is 443, false otherwise.
+
+##### tls-hostname
+
 Recognized values: string
 
 Allows to pass SAN for TLS validation.
 
 For compatibility with the cgo implementation you may also use `ssl`
-instead of `tls` and pass `CN=<SAN>` instead of `<SAN>`.
+instead of `tls-hostname` and pass `CN=<SAN>` instead of `<SAN>`.
 
 Defaults to empty string.
 

--- a/libase/libdsn/dsn.go
+++ b/libase/libdsn/dsn.go
@@ -29,7 +29,8 @@ type Info struct {
 
 	ClientHostname string `json:"client-hostname"`
 
-	TLSHostname       string `json:"tls-hostname" multiref:"tls,ssl"`
+	TLSEnable         bool   `json:"tls"`
+	TLSHostname       string `json:"tls-hostname" multiref:"ssl"`
 	TLSSkipValidation bool   `json:"tls-skip-validation"`
 	TLSCAFile         string `json:"tls-ca"`
 

--- a/libase/tds/packet.go
+++ b/libase/tds/packet.go
@@ -10,6 +10,10 @@ import (
 	"io"
 )
 
+var (
+	ErrEOFAfterZeroRead = errors.New("received io.EOF after reading 0 bytes")
+)
+
 // Packet represents a single packet in a message.
 type Packet struct {
 	Header PacketHeader
@@ -54,6 +58,10 @@ func (packet *Packet) ReadFrom(reader io.Reader) (int64, error) {
 
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				if m == 0 {
+					return totalBytes, ErrEOFAfterZeroRead
+				}
+
 				// The PDU is split over multiple responses
 				if totalBytes != int64(packet.Header.Length) {
 					continue

--- a/libase/tds/packetHeader.go
+++ b/libase/tds/packetHeader.go
@@ -6,6 +6,7 @@ package tds
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -123,6 +124,9 @@ func (header *PacketHeader) ReadFrom(r io.Reader) (int64, error) {
 	bs := make([]byte, PacketHeaderSize)
 	n, err := r.Read(bs)
 	if err != nil || n != PacketHeaderSize {
+		if n == 0 && errors.Is(err, io.EOF) {
+			return 0, ErrEOFAfterZeroRead
+		}
 		return int64(n), fmt.Errorf("read %d of %d expected bytes from reader: %w", n, PacketHeaderSize, err)
 	}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Users must enable TLS explicitly by setting `ASE_TLS=true` or `Info.TLSEnable = true`.
Also defaults the expected TLS servername to be `Info.Host`.

TLS is also enabled by default when the port is 443, e.g. for TLS proxies.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
