### PR TITLE
Print package type in error

### DIFF
--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -628,7 +628,7 @@ func (tdsChan *Channel) tryParsePackage() bool {
 		}
 
 		// Parsing went wrong, record as error
-		tdsChan.errCh <- fmt.Errorf("error parsing package: %w", err)
+		tdsChan.errCh <- fmt.Errorf("error parsing package %T: %w", pkg, err)
 		return false
 	}
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Better error output.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
