### PR TITLE
Namepool for statements and later cursors

### DIFF
--- a/libase/namepool/name.go
+++ b/libase/namepool/name.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2020 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package namepool
+
+// Name is a member of a Pool. It contains the formatted string of the
+// format and the ID as well as the ID itself.
+type Name struct {
+	name string
+	id   *uint64
+
+	pool *pool
+}
+
+func (name Name) Name() string {
+	return name.name
+}
+
+func (name Name) String() string {
+	return name.Name()
+}
+
+func (name Name) ID() uint64 {
+	return *name.id
+}
+
+// Release calls to the Names' Pool to release itself. The
+// restrictions and affects of Pool.Release apply.
+func (name *Name) Release() {
+	name.pool.Release(name)
+}

--- a/libase/namepool/pool.go
+++ b/libase/namepool/pool.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2020 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package namepool
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+type pool struct {
+	format    string
+	idCounter uint64
+	idPool    *sync.Pool
+}
+
+// Pool is a wrapper around a sync.Pool utilizing sync/atomic to provide
+// simple name pools that are safe to use by multiple goroutines.
+//
+// The argument format should include exactly one format verb for base
+// 10 integers (%d).
+// It is not an error if format doesn't include any verbs. The ID will
+// still be stored in acquired Names.
+func Pool(format string) *pool {
+	pool := &pool{
+		format:    format,
+		idCounter: 0,
+	}
+
+	pool.idPool = &sync.Pool{
+		New: func() interface{} {
+			newId := atomic.AddUint64(&pool.idCounter, 1)
+			return &newId
+		},
+	}
+
+	return pool
+}
+
+// Acquire returns a Name from the name pool.
+func (pool *pool) Acquire() *Name {
+	id := pool.idPool.Get().(*uint64)
+
+	return &Name{
+		name: fmt.Sprintf(pool.format, *id),
+		id:   id,
+	}
+}
+
+// Release returns a name to the name pool. The value name points to
+// will be reset to a default Name.
+func (pool *pool) Release(name *Name) {
+	pool.idPool.Put(name.id)
+	*name = Name{}
+}

--- a/libase/namepool/pool_test.go
+++ b/libase/namepool/pool_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2020 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package namepool
+
+import (
+	"testing"
+)
+
+func TestNewPool(t *testing.T) {
+	cases := map[string]struct {
+		format string
+		first  string
+	}{
+		"empty": {
+			format: "",
+			first:  "%!(EXTRA uint64=1)",
+		},
+		"only id": {
+			format: "%d",
+			first:  "1",
+		},
+		"format with only %d": {
+			format: "name %d",
+			first:  "name 1",
+		},
+		"format with multiple formats": {
+			format: "name %d %d %s",
+			first:  "name 1 %!d(MISSING) %!s(MISSING)",
+		},
+		"format with string verb": {
+			format: "name %s",
+			first:  "name %!s(uint64=1)",
+		},
+	}
+
+	for title, cas := range cases {
+		t.Run(title, func(t *testing.T) {
+			pool := Pool(cas.format)
+			name := pool.Acquire()
+			defer pool.Release(name)
+
+			if name.Name() != cas.first {
+				t.Errorf("Expected to receive '%s' as first name, received: %s", cas.first, name.Name())
+			}
+		})
+	}
+}
+
+func TestPool_Release(t *testing.T) {
+	pool := Pool("%d")
+
+	name := pool.Acquire()
+	if name == nil {
+		t.Errorf("Acquired Name is nil")
+		return
+	}
+
+	pool.Release(name)
+	if name.id != nil {
+		t.Errorf("Released Name has non-nil ID pointer")
+	}
+	if (*name).name != "" {
+		t.Errorf("Released Name has non-empty name")
+	}
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Adds the package `libase/namepool`, providing `Pool` and `Name` to provide a small wrapper around sync.Pool for statements and cursor.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
