### PR TITLE
Handle empty rows

### DIFF
--- a/purego/genericExec.go
+++ b/purego/genericExec.go
@@ -98,9 +98,5 @@ func (c *Conn) genericResults(ctx context.Context) (driver.Rows, driver.Result, 
 		return nil, nil, err
 	}
 
-	if rows.RowFmt == nil {
-		return nil, result, nil
-	}
-
 	return rows, result, nil
 }

--- a/purego/rows.go
+++ b/purego/rows.go
@@ -29,6 +29,10 @@ type Rows struct {
 }
 
 func (rows Rows) Columns() []string {
+	if rows.RowFmt == nil {
+		return []string{}
+	}
+
 	// TODO ignore hidden columns
 	response := make([]string, len(rows.RowFmt.Fmts))
 
@@ -55,6 +59,10 @@ func (rows *Rows) Close() error {
 }
 
 func (rows *Rows) Next(dst []driver.Value) error {
+	if rows.RowFmt == nil && len(dst) == 0 {
+		return io.EOF
+	}
+
 	_, err := rows.Conn.Channel.NextPackageUntil(context.Background(), true,
 		func(pkg tds.Package) (bool, error) {
 			switch typed := pkg.(type) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

@fwilhelm92 found a hang in database/sql when executing a `.Query` method on database/sql that doesn't yield any rows. We traced that to database/sql's inability to handle a nil rows.
Additionally I've found that database/sql panics on a nil rows on `db.Query` methods.

This PR changes the purego implementation to always return a valid `driver.Rows` and handles being effectively empty.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
