### PR TITLE
Check for empty rows struct in libase/term

### DIFF
--- a/libase/term/helpers.go
+++ b/libase/term/helpers.go
@@ -79,6 +79,11 @@ func processRows(rows driver.Rows) error {
 	}
 
 	colNames := rows.Columns()
+	// Check if rows is empty
+	if len(colNames) == 0 {
+		return nil
+	}
+
 	colLengths := map[int]int{}
 
 	fmt.Printf("|")


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Fix for libase/term printing a single pipe on empty rows structs after behaviour change in #157 

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
