### PR TITLE
Consume and discard rows on .Exec calls that produce rows

### DIFF
--- a/purego/conn.go
+++ b/purego/conn.go
@@ -111,7 +111,12 @@ func (c *Conn) Close() error {
 }
 
 func (c *Conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
-	_, result, err := c.GenericExec(ctx, query, args)
+	rows, result, err := c.GenericExec(ctx, query, args)
+
+	if rows != nil {
+		rows.Close()
+	}
+
 	return result, err
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Consume and discard rows on .ExecContext calls, e.g. `sp_configure` tends to return rows but are usually executed using .Exec, which causes packages to not be read and fail successive queries.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
