### PR TITLE
Consume and discard rows 2nd

### DIFF
--- a/examples/purego/deferred_exec/main.go
+++ b/examples/purego/deferred_exec/main.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2020 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// This example shows how to utilize deferred queries to reset options
+// on the TDS server.
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"math"
+
+	"github.com/SAP/go-ase/libase/libdsn"
+	_ "github.com/SAP/go-ase/purego"
+)
+
+func main() {
+	if err := DoMain(); err != nil {
+		log.Fatalf("Failed: %v", err)
+	}
+}
+
+func DoMain() error {
+	dsn, err := libdsn.NewInfoFromEnv("")
+	if err != nil {
+		return fmt.Errorf("error reading DSN info from env: %w", err)
+	}
+
+	fmt.Println("Opening database")
+	db, err := sql.Open("ase", dsn.AsSimple())
+	if err != nil {
+		return fmt.Errorf("failed to open connection to database: %w", err)
+	}
+	defer db.Close()
+
+	fmt.Println("configuring errorlog size")
+	if _, err := db.Exec("sp_configure 'errorlog size', 1"); err != nil {
+		return fmt.Errorf("error configuring errorlog size: %w", err)
+	}
+
+	defer func() {
+		fmt.Println("resetting errorlog size")
+		if _, err := db.Exec("sp_configure 'errorlog size', 1024"); err != nil {
+			fmt.Printf("error resetting errorlog size: %v", err)
+			return
+		}
+		fmt.Println("reset errorlog size")
+	}()
+
+	fmt.Println("doSimple on sql.DB")
+	if err := doSimple(db); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func doSimple(db *sql.DB) error {
+	if _, err := db.Exec("if object_id('simple') is not null drop table simple"); err != nil {
+		return fmt.Errorf("failed to drop table 'simple': %w", err)
+	}
+
+	fmt.Println("Creating table 'simple'")
+	if _, err := db.Exec("create table simple (a int, b char(30))"); err != nil {
+		return fmt.Errorf("failed to create table: %w", err)
+	}
+
+	fmt.Printf("Writing a=%d, b='a string' to table\n", math.MaxInt32)
+	if _, err := db.Exec("insert into simple (a, b) values (?, ?)", math.MaxInt32, "a string"); err != nil {
+		return fmt.Errorf("failed to insert values: %w", err)
+	}
+
+	fmt.Println("Querying values from table")
+	rows, err := db.Query("select * from simple")
+	if err != nil {
+		return fmt.Errorf("querying failed: %w", err)
+	}
+	defer rows.Close()
+
+	fmt.Println("Displaying results of query")
+	colNames, err := rows.Columns()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve column names: %w", err)
+	}
+
+	fmt.Printf("| %-10s | %-30s |\n", colNames[0], colNames[1])
+	format := "| %-10d | %-30s |\n"
+
+	var a int
+	var b string
+
+	for rows.Next() {
+		if err = rows.Scan(&a, &b); err != nil {
+			return fmt.Errorf("failed to scan row: %w", err)
+		}
+
+		fmt.Printf(format, a, b)
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error reading rows: %w", err)
+	}
+
+	return nil
+}

--- a/examples/purego/deferred_exec/main_test.go
+++ b/examples/purego/deferred_exec/main_test.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2020 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// +build integration
+
+package main
+
+import "log"
+
+func ExampleDoMain() {
+	if err := DoMain(); err != nil {
+		log.Printf("Failed to execute example: %v", err)
+	}
+	// Output:
+	//
+	// Opening database
+	// configuring errorlog size
+	// doSimple on sql.DB
+	// Creating table 'simple'
+	// Writing a=2147483647, b='a string' to table
+	// Querying values from table
+	// Displaying results of query
+	// | a          | b                              |
+	// | 2147483647 | a string                       |
+	// resetting errorlog size
+	// reset errorlog size
+}

--- a/libase/tds/channel.go
+++ b/libase/tds/channel.go
@@ -371,6 +371,11 @@ func (tdsChan *Channel) NextPackageUntil(ctx context.Context, wait bool, process
 			return nil, err
 		}
 
+		// Set wait to true - if a package was read without an error
+		// then more packages will be received until the processPkg
+		// function signals that the communication has finished.
+		wait = true
+
 		if eed, ok := pkg.(*EEDPackage); ok {
 			eedError.Add(eed)
 			continue

--- a/purego/rows.go
+++ b/purego/rows.go
@@ -131,6 +131,9 @@ func (rows *Rows) NextResultSet() error {
 			case *tds.RowPackage, *tds.OrderByPackage:
 				return true, nil
 			case *tds.DonePackage:
+				if typed.Status&tds.TDS_DONE_MORE == tds.TDS_DONE_MORE {
+					return false, nil
+				}
 				return true, fmt.Errorf("go-ase: no next result set: %w", io.EOF)
 			default:
 				return false, fmt.Errorf("unhandled package type %T: %v", pkg, pkg)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

When `.Exec` or similar methods are executed which return packages for purego.Rows the struct is closed immediately.
For closing Rows.NextResultSet is utilized to consume all packages - which in turn uses `Channel.NextPackageUntil` without a wait.

If the TDS server does not send packages fast enough the `NextPackageUntil` method may return too early, causing either subsequent commands to fail or the package channel to be saturated, preventing any further packages to be read - depending on the number of packages resulting from the original command.

This PR also adds an example that tests this behaviour.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
