### PR TITLE
Fix packet sizes

### DIFF
--- a/libase/tds/conn.go
+++ b/libase/tds/conn.go
@@ -176,11 +176,15 @@ func (tds *Conn) Close() error {
 	return me
 }
 
-func (tds Conn) PacketSize() int {
+func (tds *Conn) PacketSize() int {
+	// Must be pointer-receive as it is passed to Channels to acquire
+	// the negotiated packet size.
 	return tds.packetSize
 }
 
-func (tds Conn) PacketBodySize() int {
+func (tds *Conn) PacketBodySize() int {
+	// Must be pointer-receive as it is passed to Channels to acquire
+	// the negotiated packet size.
 	return tds.packetSize - PacketHeaderSize
 }
 


### PR DESCRIPTION
The methods Conn.PacketSize and Conn.PacketBodySize must be pointer
receivers, otherwise they operate on their own copy of Conn at the time
of them being passed to the Channels.

<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

The methods Conn.PacketSize and Conn.PacketBodySize must be pointer
receivers, otherwise they operate on their own copy of Conn at the time
of them being passed to the Channels.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
