### PR TITLE
Larger dynamic SQL

### DIFF
--- a/libase/tds/packageDynamic.go
+++ b/libase/tds/packageDynamic.go
@@ -45,6 +45,12 @@ type DynamicPackage struct {
 	wide bool
 }
 
+func NewDynamicPackage(wide bool) *DynamicPackage {
+	dyn := new(DynamicPackage)
+	dyn.wide = wide
+	return dyn
+}
+
 func (pkg *DynamicPackage) ReadFrom(ch BytesChannel) error {
 	var totalLength int
 	var err error

--- a/libase/tds/packageDynamic.go
+++ b/libase/tds/packageDynamic.go
@@ -7,6 +7,7 @@ package tds
 import (
 	"errors"
 	"fmt"
+	"math"
 )
 
 //go:generate stringer -type=DynamicOperationType
@@ -131,24 +132,47 @@ func (pkg *DynamicPackage) WriteTo(ch BytesChannel) error {
 		return err
 	}
 
+	// maxLength is the maximum length of bytes for the package
+	maxLength := math.MaxInt16
+	if pkg.wide {
+		maxLength = math.MaxInt32
+	}
+	// userMaxLength is the maximum length of bytes for values the user
+	// can supply
+	userMaxLength := maxLength
+
 	// 1  dynamicType
 	// 1  dynamicStatus
 	// 1  id length
 	// x  id
 	totalLength := 3 + len(pkg.ID)
+	userMaxLength -= 3
 	if pkg.Type&TDS_DYN_PREPARE == TDS_DYN_PREPARE || pkg.Type&TDS_DYN_EXEC_IMMED == TDS_DYN_EXEC_IMMED {
 		// 2  stmt length if !pkg.wide
 		// 4 stmt length if pkg.wide
 		// x  stmt
 		totalLength += 2 + len(pkg.Stmt)
+		userMaxLength -= 2
 		if pkg.wide {
 			// add two more bytes for TDS_DYNAMIC2
 			totalLength += 2
+			userMaxLength -= 2
 		}
 	}
 
-	if err := ch.WriteUint16(uint16(totalLength)); err != nil {
-		return err
+	if totalLength >= maxLength {
+		return fmt.Errorf("tds: query too long, statement ID and query can at most be %d bytes long",
+			userMaxLength)
+	}
+
+	if pkg.wide {
+		if err := ch.WriteUint32(uint32(totalLength)); err != nil {
+			return err
+		}
+	} else {
+		if err := ch.WriteUint16(uint16(totalLength)); err != nil {
+			return err
+		}
 	}
 
 	if err := ch.WriteByte(byte(pkg.Type)); err != nil {

--- a/purego/dynamic.go
+++ b/purego/dynamic.go
@@ -62,9 +62,8 @@ func (c *Conn) NewStmt(ctx context.Context, name, query string, create_proc bool
 		name = stmt.stmtId.Name()
 	}
 
-	stmt.pkg = &tds.DynamicPackage{
-		ID: name,
-	}
+	stmt.pkg = tds.NewDynamicPackage(true)
+	stmt.pkg.ID = name
 
 	if create_proc {
 		stmt.pkg.Stmt = fmt.Sprintf("create proc %s as %s", name, query)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

- Create TDS_DYNAMIC2 instead of TDS_DYNAMIC, allowing ~double the length of statements
- Validate the length of statements to display a descriptive error

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
