### PR TITLE
Document context use of tds.NewConn and do not pass context from data…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
     steps:
       # Setup go and stringer
       - uses: actions/setup-go@v2
-      - run: echo "::set-env name=PATH::$(go env GOPATH)/bin:$PATH"
       - run: go get -v golang.org/x/tools/cmd/stringer
 
       # Setup python and reuse
@@ -61,7 +60,7 @@ jobs:
 
       # Generate
       - uses: actions/checkout@v2
-      - run: make generate
+      - run: PATH="$(go env GOPATH)/bin:$PATH" make generate
       - run: |
           if [ "$(git status --porcelain | wc -l)" -ne 0 ]; then
             printf '::error ::%s' '`make generate` left or changed files'

--- a/libase/tds/conn.go
+++ b/libase/tds/conn.go
@@ -47,6 +47,10 @@ type Conn struct {
 }
 
 // Dial returns a prepared and dialed Conn.
+//
+// A new child context will be created from the passed context and used
+// to abort any interaction with the server - hence closing the parent
+// context will abort all interaction with the server.
 func NewConn(ctx context.Context, dsn *libdsn.Info) (*Conn, error) {
 	network := "tcp"
 	if prop := dsn.Prop("network"); prop != "" {

--- a/purego/conn.go
+++ b/purego/conn.go
@@ -43,8 +43,12 @@ func NewConnWithHooks(ctx context.Context, dsn *libdsn.Info, envChangeHooks []td
 		stmtLock: &sync.RWMutex{},
 	}
 
+	// Cannot pass the passed context along here as tds.NewConn creates
+	// a child context from the passed context.
+	// Otherwise the context isn't being used, so using
+	// context.Background is fine.
 	var err error
-	conn.Conn, err = tds.NewConn(ctx, dsn)
+	conn.Conn, err = tds.NewConn(context.Background(), dsn)
 	if err != nil {
 		return nil, fmt.Errorf("go-ase: error opening connection to TDS server: %w", err)
 	}


### PR DESCRIPTION
…base/sql call

<!--
SPDX-FileCopyrightText: 2020 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

If a user passes a timeout context to database/sql.Open* the connection will close after the timeout finishes or is cancelled.
For tds.NewConn this behaviour is desired, for purego.NewConn it is not.

**Related issues**

Link any related issues here.

**Tests**

- [x] make lint
- [x] make test-go / make test-cgo
- [x] make integration-go / make integration-cgo
