### PR TITLE
Revert "Bump golangci/golangci-lint-action from v2.4.0 to v2.5.1"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-      - uses: golangci/golangci-lint-action@v2.5.1
+      - uses: golangci/golangci-lint-action@v2.4.0
         with:
           version: v1.28
           # github.head_ref is only set on pull_request runs, not for


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

This reverts commit 4b110da8bc03700e78e6809e34987a40cf52c703.

`golangci-lint-action` v2.5.1 seems to cause some issues. Therefore, the commit is reverted.

**Tests**

- [ ] make lint
- [ ] make integration
