### PR TITLE
Fix 'order by' clauses breaking rows objects

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -256,6 +256,8 @@ func (cursor *Cursor) allocateOnServer(ctx context.Context, query string, args [
 		case *tds.ControlPackage:
 			// TODO
 			return false, nil
+		case *tds.OrderByPackage, *tds.OrderBy2Package:
+			return false, nil
 		case *tds.DonePackage:
 			ok, err := handleDonePackage(typed)
 			if err != nil {

--- a/examples/order_by/main_test.go
+++ b/examples/order_by/main_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2021 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// +build integration
+
+package main
+
+import "log"
+
+func ExampleDoMain() {
+	if err := DoMain(); err != nil {
+		log.Printf("Failed to execute example: %v", err)
+	}
+	// Output:
+	//
+	// Opening database
+	// Creating table 'order_by'
+	// Query without cursor
+	// Querying values from table without ordering
+	// | a          | b                              |
+	// | 1          | one                            |
+	// | 0          | zero                           |
+	// | 4          | four                           |
+	// | 3          | three                          |
+	// Querying values from table with ordering
+	// | a          | b                              |
+	// | 0          | zero                           |
+	// | 1          | one                            |
+	// | 3          | three                          |
+	// | 4          | four                           |
+	// Query with cursor
+	// Querying values from table without ordering
+	// | a          | b                              |
+	// | 1          | one                            |
+	// | 0          | zero                           |
+	// | 4          | four                           |
+	// | 3          | three                          |
+	// Querying values from table with ordering
+	// | a          | b                              |
+	// | 0          | zero                           |
+	// | 1          | one                            |
+	// | 3          | three                          |
+	// | 4          | four                           |
+}

--- a/rows.go
+++ b/rows.go
@@ -189,7 +189,7 @@ func (rows *Rows) Next(dst []driver.Value) error {
 				rows.RowFmt = typed
 				rows.hasNextResultSet = true
 				return false, io.EOF
-			case *tds.OrderByPackage:
+			case *tds.OrderByPackage, *tds.OrderBy2Package:
 				return false, nil
 			case *tds.DonePackage:
 				ok, err := handleDonePackage(typed)
@@ -241,7 +241,7 @@ func (rows *Rows) NextResultSet() error {
 				rows.RowFmt = typed
 				rows.hasNextResultSet = true
 				return false, nil
-			case *tds.RowPackage, *tds.OrderByPackage:
+			case *tds.RowPackage, *tds.OrderByPackage, *tds.OrderBy2Package:
 				return true, nil
 			case *tds.DonePackage:
 				if typed.Status&tds.TDS_DONE_MORE == tds.TDS_DONE_MORE {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Missing handling of 'order by' packages breaks query reads.

**Related issues**

#183 

**Tests**

- [x] make lint
- [x] make integration
