### PR TITLE
Fix linter workflow by tidying go.sum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+      - run: go mod tidy -v
       - uses: golangci/golangci-lint-action@v2.4.0
         with:
           version: v1.28

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+
 github.com/SAP/go-dblib v0.0.0-20210129100507-ad8fcb5232aa h1:7sR1xksKUl0n3k1Mtm1yOdGc5B+NmqQUxtcMXR5cHjY=
 github.com/SAP/go-dblib v0.0.0-20210129100507-ad8fcb5232aa/go.mod h1:+J5fa7eSdQ3ig2CqOarENCW3L2vPdDF+hl0N5h5pXOU=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Attempt to fix linter by tidying go.sum before executing linter.
See https://github.com/SAP/go-dblib/pull/30

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make integration
