### PR TITLE
Mark rows as closed to prevent stalling by attempting to read packages

### DIFF
--- a/cursorRows.go
+++ b/cursorRows.go
@@ -30,8 +30,6 @@ var (
 type CursorRows struct {
 	cursor *Cursor
 	rows   chan *tds.RowPackage
-	// TODO this is just a workaround
-	rowsClosed bool
 
 	baseRows
 
@@ -196,9 +194,9 @@ func (rows *CursorRows) fetch(ctx context.Context) error {
 	}
 
 	if err != nil {
-		if !rows.rowsClosed {
+		if !rows.isClosed() {
 			close(rows.rows)
-			rows.rowsClosed = true
+			rows.closed = true
 		}
 		if errors.Is(err, io.EOF) {
 			return ErrCurNoMoreRows

--- a/genericExec.go
+++ b/genericExec.go
@@ -93,5 +93,12 @@ func (c *Conn) genericResults(ctx context.Context) (driver.Rows, driver.Result, 
 		return nil, nil, err
 	}
 
+	// If the error is an io.EOF the transaction has ended and
+	// attempting to read results through rows would stall the
+	// application.
+	if errors.Is(err, io.EOF) {
+		rows.closed = true
+	}
+
 	return rows, result, nil
 }

--- a/integration_genericExec_test.go
+++ b/integration_genericExec_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2021 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// +build integration
+
+package ase
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/SAP/go-dblib/integration"
+)
+
+func TestDirectExec(t *testing.T) {
+
+	t.Run("SelectNoArgs", func(t *testing.T) {
+		integration.TestForEachDB("TestDirectExecSelectNoArgs", t, func(t *testing.T, db *sql.DB, tableName string) {
+			directExecWrapper(t, db, tableName, "select * from %s", nil)
+		})
+	})
+
+	t.Run("SelectWithArgs", func(t *testing.T) {
+		integration.TestForEachDB("TestDirectExecSelectWithArgs", t, func(t *testing.T, db *sql.DB, tableName string) {
+			directExecWrapper(t, db, tableName, "select * from %s where b like ?", "three")
+		})
+	})
+
+	t.Run("UpdateNoArgs", func(t *testing.T) {
+		integration.TestForEachDB("TestDirectExecUpdateNoArgs", t, func(t *testing.T, db *sql.DB, tableName string) {
+			directExecWrapper(t, db, tableName, "update %s set b = \"five\"")
+		})
+	})
+
+	t.Run("UpdateWithArgs", func(t *testing.T) {
+		integration.TestForEachDB("TestDirectExecUpdateWithArgs", t, func(t *testing.T, db *sql.DB, tableName string) {
+			directExecWrapper(t, db, tableName, "update %s set b = \"five\" where b like ?", "three")
+		})
+	})
+
+}
+
+func directExecWrapper(t *testing.T, db *sql.DB, tableName, query string, args ...interface{}) {
+	timeout, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	wrapper(t, db, tableName,
+		func(t *testing.T, conn *Conn, tableName string) {
+			rows, result, err := conn.DirectExec(timeout, fmt.Sprintf(query, tableName), args...)
+			if err != nil {
+				t.Errorf("received error on DirectExec: %v", err)
+				return
+			}
+
+			if rows == nil {
+				t.Errorf("received nil rows")
+			} else {
+				fetchRows(t, rows)
+				if err := rows.Close(); err != nil {
+					t.Errorf("error closing rows: %v", err)
+				}
+			}
+
+			if result == nil {
+				t.Errorf("received nil result")
+			}
+		},
+	)
+}

--- a/integration_helpers_test.go
+++ b/integration_helpers_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2021 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// +build integration
+
+package ase
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+// wrapper is used to wrap tests for the underlying driver connection in
+// integration tests.
+func wrapper(t *testing.T, db *sql.DB, tableName string, runner func(*testing.T, *Conn, string)) {
+	if err := createTable(db, tableName); err != nil {
+		t.Errorf("error creating table: %v", err)
+		return
+	}
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Errorf("error getting conn from sql.DB: %v", err)
+		return
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			t.Errorf("error closing conn from sql.DB: %v", err)
+		}
+	}()
+
+	conn.Raw(func(driverConn interface{}) error {
+		aseConn, ok := driverConn.(*Conn)
+		if !ok {
+			t.Errorf("received driverConn is not *Conn: %v", err)
+			return nil
+		}
+
+		runner(t, aseConn, tableName)
+		return nil
+	})
+}
+
+// interface to match both Rows and CursorRows.
+type sqlRows interface {
+	Next([]driver.Value) error
+}
+
+// fetchRows expects the passed rows to return {int, string} and prints
+// all rows to stdout.
+//
+// rows is not closed automatically.
+func fetchRows(t *testing.T, rows sqlRows) {
+	values := []driver.Value{0, ""}
+	for {
+		if err := rows.Next(values); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Errorf("error reading row: %v", err)
+			return
+		}
+
+		fmt.Printf("| %d | %s |\n", values[0], values[1])
+	}
+}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

The application may stall when a rows object is accessed but no rows are sent by ASE.

If possible go-ase marks rows as already closed to prevent stalling.

Returning a nil rows isn't viable as this would require additional code on the users side to handle a nil value.

**Related issues**

Requires SAP/go-dblib#33

**Tests**

- [x] make lint
- [x] make integration
