### PR TITLE
Allow disabling automatic use of cursors by context value NoQueryCursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ used hardware this may perform worse than a simple query.
 It is strongly suggested to profile this option with your queries before
 enabling it.
 
+Altneratively you can pass this option on a per-query basis in the context.
+See the documentation of Conn.QueryContext for details.
+
 ## Limitations
 
 ### Beta


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Allow enabling/disabling automatic use of cursors by context value `NoQueryCursor`, ignoring the connections' configuration.

**Related issues**

\-

**Tests**

- [x] make lint
- [x] make integration
