### PR TITLE
Adjust examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ report:
 	$(GO) tool cover -html=/tmp/cov.out -o ./report.html
 	rm /tmp/cov.out
 
-EXAMPLES := $(wildcard examples/*)
+EXAMPLES := $(filter-out $(wildcard examples/*.go), $(wildcard examples/*))
 
 examples: $(EXAMPLES)
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ report:
 	$(GO) tool cover -html=/tmp/cov.out -o ./report.html
 	rm /tmp/cov.out
 
-EXAMPLES := $(filter-out $(wildcard examples/*.go), $(wildcard examples/*))
+EXAMPLES := $(dir $(wildcard examples/*/main.go))
 
 examples: $(EXAMPLES)
 

--- a/examples/cursor/main_test.go
+++ b/examples/cursor/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/directExec/main_test.go
+++ b/examples/directExec/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/eedexample/main_test.go
+++ b/examples/eedexample/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/noQueryCursor/main_test.go
+++ b/examples/noQueryCursor/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/preparedStatement/main_test.go
+++ b/examples/preparedStatement/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/recorder/main_test.go
+++ b/examples/recorder/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/simple/main_test.go
+++ b/examples/simple/main_test.go
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/template/main_test.go
+++ b/examples/template/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main

--- a/examples/transaction/main_test.go
+++ b/examples/transaction/main_test.go
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
 // +build integration
 
 package main


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE
SPDX-FileCopyrightText: 2022 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

- Makefile: Filter files that are not used as examples, e.g. `examples/helpers.go`
- examples/*/main_test.go: Add additional build-tag

**Tests**

- [x] make lint
- [x] make integration
