### PR TITLE
Use govulncheck action instead of latest binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,7 @@ jobs:
           only-new-issues: ${{ github.head_ref != '' }}
 
       - name: Check for go vulnerabilities
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck -v -test ./...
+        uses: golang/govulncheck-action@v1
 
   generate-required:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 SAP SE
SPDX-FileCopyrightText: 2021 SAP SE
SPDX-FileCopyrightText: 2022 SAP SE
SPDX-FileCopyrightText: 2023 SAP SE

SPDX-License-Identifier: Apache-2.0
-->

**Description**

Describe what the PR accomplishes

**Related issues**

Link any related issues here.

**Tests**

- [ ] make lint
- [ ] make integration
